### PR TITLE
Feat/soroban math

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ coverage/
 *.njsproj
 *.sln
 *.sw?
+CLAUDE.md
+plan.md

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   - [simulate_transaction](#simulate_transaction)
   - [decode_ledger_entry](#decode_ledger_entry)
   - [submit_transaction](#submit_transaction)
+  - [soroban_math](#soroban_math)
 - [Example Prompts & Workflows](#example-prompts--workflows)
 - [Soroban CLI Integration](#soroban-cli-integration)
 - [Development Guide](#development-guide)
@@ -88,6 +89,7 @@ There is currently **no community-driven MCP server** for Stellar, which means:
 | **Transaction Simulation** | Dry-run a Soroban transaction and inspect resource usage and return values before spending fees |
 | **Ledger Entry Decoding** | Decode raw XDR ledger entries into human-readable JSON |
 | **Transaction Submission** | Sign (via a provided secret key or external signer) and submit transactions to the network |
+| **Soroban Math** | Fixed-point arithmetic, statistical functions (mean, std dev, TWAP), and financial math (compound interest, basis points) compatible with Soroban's 7-decimal integer model |
 | **Multi-network** | Targets Mainnet, Testnet, Futurenet, or a custom RPC endpoint |
 | **Soroban CLI Backend** | Delegates complex operations to the official `stellar` / `soroban` CLI for maximum correctness |
 | **Structured Output** | All tool responses are typed JSON objects the AI can directly parse and act upon |
@@ -640,6 +642,52 @@ Sign (optionally) and submit a transaction to the Stellar network. If `STELLAR_S
 
 ---
 
+### `soroban_math`
+
+Perform fixed-point arithmetic, statistical, and financial math operations using Soroban-compatible 7-decimal integer representations. All numeric values are passed as strings to preserve precision with large integers.
+
+**Operations:**
+
+| `operation` | Description | Key Parameters |
+|---|---|---|
+| `fixed_add` | Add two fixed-point numbers | `a`, `b`, `decimals` |
+| `fixed_sub` | Subtract two fixed-point numbers | `a`, `b`, `decimals` |
+| `fixed_mul` | Multiply two fixed-point numbers | `a`, `b`, `decimals` |
+| `fixed_div` | Divide two fixed-point numbers | `a`, `b`, `decimals` |
+| `mean` | Arithmetic mean of a list of values | `values[]`, `decimals` |
+| `weighted_mean` | Weighted mean of values with corresponding weights | `values[]`, `weights[]`, `decimals` |
+| `std_dev` | Population standard deviation | `values[]` (≥ 2), `decimals` |
+| `twap` | Time-weighted average price | `prices[]{price, timestamp}` (≥ 2), `decimals` |
+| `compound_interest` | Compound interest final amount | `principal`, `rate_bps`, `periods`, `compounds_per_period`, `decimals` |
+| `basis_points_to_percent` | Convert basis points to a percentage | `value` |
+| `percent_to_basis_points` | Convert a percentage to basis points | `value` |
+
+**Common Parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `operation` | `string` | Yes | One of the operation names above |
+| `decimals` | `integer` | No | Fixed-point decimal places (0–18, default `7` — Stellar's standard) |
+
+**Output:**
+
+```jsonc
+{
+  "operation": "fixed_mul",
+  "result": "10000000",     // raw integer string
+  "human_readable": "1.0000000",
+  "decimals": 7
+}
+```
+
+For `basis_points_to_percent` / `percent_to_basis_points` the output contains only `operation` and `result` (a number, not a fixed-point integer).
+
+**Example prompt:**
+
+> _"What is the compound interest on a principal of 1,000 USDC at 5% annual rate (500 bps) over 12 monthly periods?"_
+
+---
+
 ## Example Prompts & Workflows
 
 These are real-world workflows that become possible once pulsar is connected to your AI assistant.
@@ -821,6 +869,7 @@ npm run typecheck
 - [x] `simulate_transaction` — dry-run via Soroban RPC
 - [x] `decode_ledger_entry` — XDR decode
 - [x] `submit_transaction` — broadcast + wait for result
+- [x] `soroban_math` — fixed-point, statistical, and financial math
 - [ ] `get_transaction_history` — paginated history for an account
 - [ ] `stream_events` — subscribe to Soroban contract events
 - [ ] `build_transaction` — construct a Soroban invoke transaction from contract spec + args (without needing pre-built XDR)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,24 @@
 #!/usr/bin/env node
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema, ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ErrorCode,
+  McpError,
+} from '@modelcontextprotocol/sdk/types.js';
 
-import { config } from "./config.js";
-import { fetchContractSpec, fetchContractSpecSchema } from "./tools/fetch_contract_spec.js";
+import { config } from './config.js';
+import { fetchContractSpec, fetchContractSpecSchema } from './tools/fetch_contract_spec.js';
 import { submitTransaction } from './tools/submit_transaction.js';
 import { simulateTransaction } from './tools/simulate_transaction.js';
 import { getAccountBalance } from './tools/get_account_balance.js';
+import { sorobanMath } from './tools/soroban_math.js';
 import {
   GetAccountBalanceInputSchema,
   SubmitTransactionInputSchema,
   SimulateTransactionInputSchema,
+  SorobanMathInputSchema,
 } from './schemas/tools.js';
 import logger from './logger.js';
 import { PulsarError, PulsarNetworkError, PulsarValidationError } from './errors.js';
@@ -34,7 +41,7 @@ class PulsarServer {
         capabilities: {
           tools: {},
         },
-      },
+      }
     );
 
     this.setupHandlers();
@@ -46,7 +53,8 @@ class PulsarServer {
       tools: [
         {
           name: 'get_account_balance',
-          description: 'Get the current XLM and issued asset balances for a Stellar account. Optionally filter by asset code and/or issuer.',
+          description:
+            'Get the current XLM and issued asset balances for a Stellar account. Optionally filter by asset code and/or issuer.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -112,28 +120,29 @@ class PulsarServer {
           },
         },
         {
-          name: "fetch_contract_spec",
+          name: 'fetch_contract_spec',
           description:
-            "Fetch the ABI/interface spec of a deployed Soroban contract. Returns decoded function signatures, parameter types, and emitted event schemas.",
+            'Fetch the ABI/interface spec of a deployed Soroban contract. Returns decoded function signatures, parameter types, and emitted event schemas.',
           inputSchema: {
-            type: "object",
+            type: 'object',
             properties: {
               contract_id: {
-                type: "string",
-                description: "The Soroban contract address (C...)",
+                type: 'string',
+                description: 'The Soroban contract address (C...)',
               },
               network: {
-                type: "string",
-                enum: ["mainnet", "testnet", "futurenet", "custom"],
-                description: "Override the active network for this call.",
+                type: 'string',
+                enum: ['mainnet', 'testnet', 'futurenet', 'custom'],
+                description: 'Override the active network for this call.',
               },
             },
-            required: ["contract_id"],
+            required: ['contract_id'],
           },
         },
         {
           name: 'simulate_transaction',
-          description: 'Simulates a transaction on the Soroban RPC and returns results, footprint, fees, and events.',
+          description:
+            'Simulates a transaction on the Soroban RPC and returns results, footprint, fees, and events.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -150,6 +159,82 @@ class PulsarServer {
             required: ['xdr'],
           },
         },
+        {
+          name: 'soroban_math',
+          description:
+            'Perform financial math on Soroban fixed-point integers (scaled by 10^decimals, default 7). ' +
+            'Operations: fixed_add, fixed_sub, fixed_mul, fixed_div (fixed-point arithmetic); ' +
+            'mean, weighted_mean, std_dev (statistics); twap (time-weighted average price); ' +
+            'compound_interest (compound growth using basis-point rate); ' +
+            'basis_points_to_percent, percent_to_basis_points (unit conversions). ' +
+            'All integer arguments are passed as decimal strings to preserve BigInt precision.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              operation: {
+                type: 'string',
+                enum: [
+                  'fixed_add',
+                  'fixed_sub',
+                  'fixed_mul',
+                  'fixed_div',
+                  'mean',
+                  'weighted_mean',
+                  'std_dev',
+                  'twap',
+                  'compound_interest',
+                  'basis_points_to_percent',
+                  'percent_to_basis_points',
+                ],
+                description: 'The math operation to perform.',
+              },
+              a: { type: 'string', description: 'First operand (fixed-point ops).' },
+              b: { type: 'string', description: 'Second operand (fixed-point ops).' },
+              decimals: {
+                type: 'number',
+                description: 'Decimal places in the fixed-point scale (default 7).',
+              },
+              values: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'Array of fixed-point values as strings (mean, weighted_mean, std_dev).',
+              },
+              weights: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'Array of weights as strings (weighted_mean).',
+              },
+              prices: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    price: { type: 'string' },
+                    timestamp: { type: 'number' },
+                  },
+                  required: ['price', 'timestamp'],
+                },
+                description: 'Array of {price, timestamp} entries for TWAP.',
+              },
+              principal: {
+                type: 'string',
+                description: 'Principal amount as fixed-point string (compound_interest).',
+              },
+              rate_bps: {
+                type: 'number',
+                description: 'Annual rate in basis points, e.g. 500 = 5% (compound_interest).',
+              },
+              periods: { type: 'number', description: 'Number of periods (compound_interest).' },
+              compounds_per_period: {
+                type: 'number',
+                description: 'Compounding frequency per period, default 1 (compound_interest).',
+              },
+              value: { type: 'number', description: 'Numeric value for basis-point conversion.' },
+            },
+            required: ['operation'],
+          },
+        },
       ],
     }));
 
@@ -163,7 +248,10 @@ class PulsarServer {
           case 'get_account_balance': {
             const parsed = GetAccountBalanceInputSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for get_account_balance`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for get_account_balance`,
+                parsed.error.format()
+              );
             }
             const result = await getAccountBalance(parsed.data);
             return {
@@ -179,16 +267,22 @@ class PulsarServer {
           case 'fetch_contract_spec': {
             const parsed = fetchContractSpecSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for fetch_contract_spec`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for fetch_contract_spec`,
+                parsed.error.format()
+              );
             }
             const result = await fetchContractSpec(parsed.data);
-            return { content: [{ type: "text", text: JSON.stringify(result) }] };
+            return { content: [{ type: 'text', text: JSON.stringify(result) }] };
           }
 
           case 'submit_transaction': {
             const parsed = SubmitTransactionInputSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for submit_transaction`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for submit_transaction`,
+                parsed.error.format()
+              );
             }
             const result = await submitTransaction(parsed.data);
             return {
@@ -199,12 +293,27 @@ class PulsarServer {
           case 'simulate_transaction': {
             const parsed = SimulateTransactionInputSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for simulate_transaction`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for simulate_transaction`,
+                parsed.error.format()
+              );
             }
             const result = await simulateTransaction(parsed.data);
             return {
               content: [{ type: 'text', text: JSON.stringify(result) }],
             };
+          }
+
+          case 'soroban_math': {
+            const parsed = SorobanMathInputSchema.safeParse(args);
+            if (!parsed.success) {
+              throw new PulsarValidationError(
+                `Invalid input for soroban_math`,
+                parsed.error.format()
+              );
+            }
+            const result = await sorobanMath(parsed.data);
+            return { content: [{ type: 'text', text: JSON.stringify(result) }] };
           }
 
           default:
@@ -226,10 +335,9 @@ class PulsarServer {
       throw error;
     } else {
       // Convert unknown errors to PulsarNetworkError as per requirements
-      pulsarError = new PulsarNetworkError(
-        error instanceof Error ? error.message : String(error),
-        { originalError: error }
-      );
+      pulsarError = new PulsarNetworkError(error instanceof Error ? error.message : String(error), {
+        originalError: error,
+      });
     }
 
     logger.error(
@@ -267,9 +375,7 @@ class PulsarServer {
   async run() {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    logger.info(
-      `pulsar MCP server v1.0.0 is running on ${config.stellarNetwork}...`,
-    );
+    logger.info(`pulsar MCP server v1.0.0 is running on ${config.stellarNetwork}...`);
   }
 }
 
@@ -278,4 +384,3 @@ pulsar.run().catch((error) => {
   logger.fatal({ error }, '❌ Fatal error in pulsar server');
   process.exit(1);
 });
-

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -6,14 +6,14 @@
  * before any RPC calls are made.
  */
 
-import { z } from "zod";
+import { z } from 'zod';
 
 import {
   StellarPublicKeySchema,
   ContractIdSchema,
   XdrBase64Schema,
   NetworkSchema,
-} from "./index.js";
+} from './index.js';
 
 /**
  * Schema for get_account_balance tool
@@ -29,9 +29,7 @@ export const GetAccountBalanceInputSchema = z.object({
   asset_issuer: StellarPublicKeySchema.optional(),
 });
 
-export type GetAccountBalanceInput = z.infer<
-  typeof GetAccountBalanceInputSchema
->;
+export type GetAccountBalanceInput = z.infer<typeof GetAccountBalanceInputSchema>;
 
 /**
  * Schema for submit_transaction tool
@@ -51,14 +49,12 @@ export const SubmitTransactionInputSchema = z.object({
   wait_timeout_ms: z
     .number()
     .int()
-    .min(1000, { message: "wait_timeout_ms must be at least 1000 ms" })
-    .max(120_000, { message: "wait_timeout_ms must not exceed 120000 ms" })
+    .min(1000, { message: 'wait_timeout_ms must be at least 1000 ms' })
+    .max(120_000, { message: 'wait_timeout_ms must not exceed 120000 ms' })
     .default(30_000),
 });
 
-export type SubmitTransactionInput = z.infer<
-  typeof SubmitTransactionInputSchema
->;
+export type SubmitTransactionInput = z.infer<typeof SubmitTransactionInputSchema>;
 
 /**
  * Schema for potential future contract_read tool.
@@ -68,9 +64,9 @@ export const ContractReadInputSchema = z.object({
   contract_id: ContractIdSchema,
   method: z
     .string()
-    .min(1, { message: "Method name cannot be empty" })
+    .min(1, { message: 'Method name cannot be empty' })
     .regex(/^[a-zA-Z_][a-zA-Z0-9_]*$/, {
-      message: "Method name must be a valid identifier",
+      message: 'Method name must be a valid identifier',
     }),
   args: z.record(z.unknown()).optional(),
 });
@@ -89,7 +85,50 @@ export const SimulateTransactionInputSchema = z.object({
   network: NetworkSchema.optional(),
 });
 
-export type SimulateTransactionInput = z.infer<
-  typeof SimulateTransactionInputSchema
->;
+export type SimulateTransactionInput = z.infer<typeof SimulateTransactionInputSchema>;
 
+const fixedArithFields = {
+  a: z.string().min(1),
+  b: z.string().min(1),
+  decimals: z.number().int().min(0).max(18).default(7),
+};
+
+export const SorobanMathInputSchema = z.discriminatedUnion('operation', [
+  z.object({ operation: z.literal('fixed_add'), ...fixedArithFields }),
+  z.object({ operation: z.literal('fixed_sub'), ...fixedArithFields }),
+  z.object({ operation: z.literal('fixed_mul'), ...fixedArithFields }),
+  z.object({ operation: z.literal('fixed_div'), ...fixedArithFields }),
+  z.object({
+    operation: z.literal('mean'),
+    values: z.array(z.string().min(1)).min(1),
+    decimals: z.number().int().min(0).max(18).default(7),
+  }),
+  z.object({
+    operation: z.literal('weighted_mean'),
+    values: z.array(z.string().min(1)).min(1),
+    weights: z.array(z.string().min(1)).min(1),
+    decimals: z.number().int().min(0).max(18).default(7),
+  }),
+  z.object({
+    operation: z.literal('std_dev'),
+    values: z.array(z.string().min(1)).min(2),
+    decimals: z.number().int().min(0).max(18).default(7),
+  }),
+  z.object({
+    operation: z.literal('twap'),
+    prices: z.array(z.object({ price: z.string().min(1), timestamp: z.number().int() })).min(2),
+    decimals: z.number().int().min(0).max(18).default(7),
+  }),
+  z.object({
+    operation: z.literal('compound_interest'),
+    principal: z.string().min(1),
+    rate_bps: z.number().int().min(0),
+    periods: z.number().int().min(1),
+    compounds_per_period: z.number().int().min(1).default(1),
+    decimals: z.number().int().min(0).max(18).default(7),
+  }),
+  z.object({ operation: z.literal('basis_points_to_percent'), value: z.number() }),
+  z.object({ operation: z.literal('percent_to_basis_points'), value: z.number() }),
+]);
+
+export type SorobanMathInput = z.infer<typeof SorobanMathInputSchema>;

--- a/src/tools/soroban_math.ts
+++ b/src/tools/soroban_math.ts
@@ -1,0 +1,138 @@
+import { SorobanMathInputSchema } from '../schemas/tools.js';
+import { PulsarValidationError } from '../errors.js';
+import type { McpToolHandler } from '../types.js';
+import {
+  fixed_add,
+  fixed_sub,
+  fixed_mul,
+  fixed_div,
+  compound_interest,
+  basis_points_to_percent,
+  percent_to_basis_points,
+  mean,
+  weighted_mean,
+  std_dev,
+  twap,
+  formatHumanReadable,
+} from '../utils/math.js';
+
+export const sorobanMath: McpToolHandler<typeof SorobanMathInputSchema> = async (
+  input: unknown
+) => {
+  const parsed = SorobanMathInputSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new PulsarValidationError('Invalid input for soroban_math', parsed.error.format());
+  }
+  const data = parsed.data;
+
+  try {
+    switch (data.operation) {
+      case 'fixed_add': {
+        const result = fixed_add(BigInt(data.a), BigInt(data.b));
+        return {
+          operation: 'fixed_add',
+          result: result.toString(),
+          human_readable: formatHumanReadable(result, data.decimals),
+          decimals: data.decimals,
+        };
+      }
+      case 'fixed_sub': {
+        const result = fixed_sub(BigInt(data.a), BigInt(data.b));
+        return {
+          operation: 'fixed_sub',
+          result: result.toString(),
+          human_readable: formatHumanReadable(result, data.decimals),
+          decimals: data.decimals,
+        };
+      }
+      case 'fixed_mul': {
+        const result = fixed_mul(BigInt(data.a), BigInt(data.b), data.decimals);
+        return {
+          operation: 'fixed_mul',
+          result: result.toString(),
+          human_readable: formatHumanReadable(result, data.decimals),
+          decimals: data.decimals,
+        };
+      }
+      case 'fixed_div': {
+        const result = fixed_div(BigInt(data.a), BigInt(data.b), data.decimals);
+        return {
+          operation: 'fixed_div',
+          result: result.toString(),
+          human_readable: formatHumanReadable(result, data.decimals),
+          decimals: data.decimals,
+        };
+      }
+      case 'mean': {
+        const result = mean(data.values.map(BigInt), data.decimals);
+        return {
+          operation: 'mean',
+          result: result.toString(),
+          human_readable: formatHumanReadable(result, data.decimals),
+          decimals: data.decimals,
+        };
+      }
+      case 'weighted_mean': {
+        const result = weighted_mean(
+          data.values.map(BigInt),
+          data.weights.map(BigInt),
+          data.decimals
+        );
+        return {
+          operation: 'weighted_mean',
+          result: result.toString(),
+          human_readable: formatHumanReadable(result, data.decimals),
+          decimals: data.decimals,
+        };
+      }
+      case 'std_dev': {
+        const result = std_dev(data.values.map(BigInt), data.decimals);
+        return {
+          operation: 'std_dev',
+          result: result.toString(),
+          human_readable: formatHumanReadable(result, data.decimals),
+          decimals: data.decimals,
+        };
+      }
+      case 'twap': {
+        const prices = data.prices.map((p) => ({
+          price: BigInt(p.price),
+          timestamp: BigInt(p.timestamp),
+        }));
+        const result = twap(prices, data.decimals);
+        return {
+          operation: 'twap',
+          result: result.toString(),
+          human_readable: formatHumanReadable(result, data.decimals),
+          decimals: data.decimals,
+        };
+      }
+      case 'compound_interest': {
+        const result = compound_interest(
+          BigInt(data.principal),
+          data.rate_bps,
+          data.periods,
+          data.compounds_per_period,
+          data.decimals
+        );
+        return {
+          operation: 'compound_interest',
+          result: result.toString(),
+          human_readable: formatHumanReadable(result, data.decimals),
+          decimals: data.decimals,
+        };
+      }
+      case 'basis_points_to_percent': {
+        const result = basis_points_to_percent(data.value);
+        return { operation: 'basis_points_to_percent', result };
+      }
+      case 'percent_to_basis_points': {
+        const result = percent_to_basis_points(data.value);
+        return { operation: 'percent_to_basis_points', result };
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new PulsarValidationError(message);
+  }
+};

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,113 @@
+const scale = (decimals: number): bigint => 10n ** BigInt(decimals);
+
+function isqrt(n: bigint): bigint {
+  if (n === 0n) return 0n;
+  let x = n;
+  let y = (x + 1n) / 2n;
+  while (y < x) {
+    x = y;
+    y = (x + n / x) / 2n;
+  }
+  return x;
+}
+
+function bigintPow(base: bigint, exp: bigint): bigint {
+  if (exp === 0n) return 1n;
+  let result = 1n;
+  let b = base;
+  let e = exp;
+  while (e > 0n) {
+    if (e % 2n === 1n) result *= b;
+    b *= b;
+    e /= 2n;
+  }
+  return result;
+}
+
+export function fixed_add(a: bigint, b: bigint): bigint {
+  return a + b;
+}
+
+export function fixed_sub(a: bigint, b: bigint): bigint {
+  return a - b;
+}
+
+export function fixed_mul(a: bigint, b: bigint, decimals: number): bigint {
+  return (a * b) / scale(decimals);
+}
+
+export function fixed_div(a: bigint, b: bigint, decimals: number): bigint {
+  if (b === 0n) throw new Error('Division by zero');
+  return (a * scale(decimals)) / b;
+}
+
+export function compound_interest(
+  principal: bigint,
+  rate_bps: number,
+  periods: number,
+  compounds_per_period: number,
+  _decimals: number
+): bigint {
+  const num = BigInt(10000 * compounds_per_period + rate_bps);
+  const den = BigInt(10000 * compounds_per_period);
+  const n = BigInt(periods * compounds_per_period);
+  return (principal * bigintPow(num, n)) / bigintPow(den, n);
+}
+
+export function basis_points_to_percent(bps: number): number {
+  return bps / 100;
+}
+
+export function percent_to_basis_points(pct: number): number {
+  return Math.round(pct * 100);
+}
+
+export function mean(values: bigint[], _decimals: number): bigint {
+  const sum = values.reduce((acc, v) => acc + v, 0n);
+  return sum / BigInt(values.length);
+}
+
+export function weighted_mean(values: bigint[], weights: bigint[], _decimals: number): bigint {
+  if (values.length !== weights.length) {
+    throw new Error('Values and weights arrays must have the same length');
+  }
+  for (const w of weights) {
+    if (w < 0n) throw new Error('Weights must be non-negative');
+  }
+  const weightSum = weights.reduce((acc, w) => acc + w, 0n);
+  if (weightSum === 0n) throw new Error('Sum of weights must be non-zero');
+  const weightedSum = values.reduce((acc, v, i) => acc + v * weights[i], 0n);
+  return weightedSum / weightSum;
+}
+
+export function std_dev(values: bigint[], _decimals: number): bigint {
+  const avg = mean(values, _decimals);
+  const variance_S2 =
+    values.reduce((acc, v) => {
+      const diff = v - avg;
+      return acc + diff * diff;
+    }, 0n) / BigInt(values.length);
+  return isqrt(variance_S2);
+}
+
+export function twap(prices: { price: bigint; timestamp: bigint }[], _decimals: number): bigint {
+  const totalTime = prices[prices.length - 1].timestamp - prices[0].timestamp;
+  if (totalTime === 0n) throw new Error('Total time span must be non-zero');
+  let weightedSum = 0n;
+  for (let i = 0; i < prices.length - 1; i++) {
+    const dt = prices[i + 1].timestamp - prices[i].timestamp;
+    weightedSum += prices[i].price * dt;
+  }
+  return weightedSum / totalTime;
+}
+
+export function formatHumanReadable(value: bigint, decimals: number): string {
+  const S = scale(decimals);
+  const negative = value < 0n;
+  const abs = negative ? -value : value;
+  const intPart = abs / S;
+  const fracPart = abs % S;
+  const fracStr = fracPart.toString().padStart(decimals, '0');
+  const formatted = decimals > 0 ? `${intPart}.${fracStr}` : `${intPart}`;
+  return negative ? `-${formatted}` : formatted;
+}

--- a/tests/unit/soroban_math.test.ts
+++ b/tests/unit/soroban_math.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  fixed_add,
+  fixed_sub,
+  fixed_mul,
+  fixed_div,
+  compound_interest,
+  basis_points_to_percent,
+  percent_to_basis_points,
+  mean,
+  weighted_mean,
+  std_dev,
+  twap,
+  formatHumanReadable,
+} from '../../src/utils/math.js';
+import { sorobanMath } from '../../src/tools/soroban_math.js';
+
+const D = 7;
+
+describe('math.ts — fixed-point arithmetic', () => {
+  it('fixed_add adds two values', () => {
+    expect(fixed_add(10000000n, 5000000n)).toBe(15000000n);
+  });
+
+  it('fixed_sub subtracts two values (can be negative)', () => {
+    expect(fixed_sub(10000000n, 15000000n)).toBe(-5000000n);
+  });
+
+  it('fixed_mul: 1.5 × 2.0 = 3.0', () => {
+    expect(fixed_mul(15000000n, 20000000n, D)).toBe(30000000n);
+  });
+
+  it('fixed_div: 1.0 / 2.0 = 0.5', () => {
+    expect(fixed_div(10000000n, 20000000n, D)).toBe(5000000n);
+  });
+
+  it('fixed_div throws on zero denominator', () => {
+    expect(() => fixed_div(10000000n, 0n, D)).toThrow('Division by zero');
+  });
+});
+
+describe('math.ts — financial', () => {
+  it('compound_interest: 100% APR doubles principal', () => {
+    expect(compound_interest(10000000n, 10000, 1, 1, D)).toBe(20000000n);
+  });
+
+  it('compound_interest: 0% rate returns principal unchanged', () => {
+    expect(compound_interest(10000000n, 0, 3, 1, D)).toBe(10000000n);
+  });
+
+  it('basis_points_to_percent: 500 bps = 5%', () => {
+    expect(basis_points_to_percent(500)).toBe(5);
+  });
+
+  it('percent_to_basis_points: 5% = 500 bps', () => {
+    expect(percent_to_basis_points(5)).toBe(500);
+  });
+
+  it('percent_to_basis_points rounds fractional bps', () => {
+    expect(percent_to_basis_points(0.125)).toBe(13);
+  });
+});
+
+describe('math.ts — statistics', () => {
+  it('mean of equal values equals that value', () => {
+    expect(mean([10000000n, 10000000n, 10000000n], D)).toBe(10000000n);
+  });
+
+  it('mean uses integer division', () => {
+    expect(mean([10000000n, 30000000n], D)).toBe(20000000n);
+  });
+
+  it('weighted_mean: equal weights = plain mean', () => {
+    const result = weighted_mean([10000000n, 30000000n], [10000000n, 10000000n], D);
+    expect(result).toBe(20000000n);
+  });
+
+  it('weighted_mean: biased weights', () => {
+    const result = weighted_mean([10000000n, 30000000n], [30000000n, 10000000n], D);
+    expect(result).toBe(15000000n);
+  });
+
+  it('weighted_mean throws on mismatched array lengths', () => {
+    expect(() => weighted_mean([10000000n], [10000000n, 20000000n], D)).toThrow('same length');
+  });
+
+  it('weighted_mean throws on negative weight', () => {
+    expect(() => weighted_mean([10000000n], [-10000000n], D)).toThrow('non-negative');
+  });
+
+  it('weighted_mean throws on zero weight sum', () => {
+    expect(() => weighted_mean([10000000n], [0n], D)).toThrow('non-zero');
+  });
+
+  it('std_dev of {1.0, 3.0} = 1.0', () => {
+    expect(std_dev([10000000n, 30000000n], D)).toBe(10000000n);
+  });
+
+  it('std_dev of identical values = 0', () => {
+    expect(std_dev([20000000n, 20000000n], D)).toBe(0n);
+  });
+});
+
+describe('math.ts — twap', () => {
+  it('twap of three evenly-spaced prices = average of first two', () => {
+    const prices = [
+      { price: 10000000n, timestamp: 0n },
+      { price: 20000000n, timestamp: 5n },
+      { price: 30000000n, timestamp: 10n },
+    ];
+    expect(twap(prices, D)).toBe(15000000n);
+  });
+
+  it('twap throws when total time is zero', () => {
+    const prices = [
+      { price: 10000000n, timestamp: 5n },
+      { price: 20000000n, timestamp: 5n },
+    ];
+    expect(() => twap(prices, D)).toThrow('non-zero');
+  });
+});
+
+describe('math.ts — formatHumanReadable', () => {
+  it('formats positive fixed-point value', () => {
+    expect(formatHumanReadable(10000000n, D)).toBe('1.0000000');
+  });
+
+  it('formats negative fixed-point value', () => {
+    expect(formatHumanReadable(-15000000n, D)).toBe('-1.5000000');
+  });
+
+  it('formats zero', () => {
+    expect(formatHumanReadable(0n, D)).toBe('0.0000000');
+  });
+
+  it('pads fractional part', () => {
+    expect(formatHumanReadable(1n, D)).toBe('0.0000001');
+  });
+
+  it('works with decimals=0', () => {
+    expect(formatHumanReadable(42n, 0)).toBe('42');
+  });
+});
+
+describe('sorobanMath tool handler', () => {
+  it('fixed_add via handler', async () => {
+    const result = (await sorobanMath({
+      operation: 'fixed_add',
+      a: '10000000',
+      b: '5000000',
+      decimals: D,
+    })) as any;
+    expect(result.result).toBe('15000000');
+    expect(result.human_readable).toBe('1.5000000');
+    expect(result.decimals).toBe(D);
+  });
+
+  it('fixed_sub via handler (negative result)', async () => {
+    const result = (await sorobanMath({
+      operation: 'fixed_sub',
+      a: '5000000',
+      b: '10000000',
+      decimals: D,
+    })) as any;
+    expect(result.result).toBe('-5000000');
+    expect(result.human_readable).toBe('-0.5000000');
+  });
+
+  it('fixed_mul via handler', async () => {
+    const result = (await sorobanMath({
+      operation: 'fixed_mul',
+      a: '15000000',
+      b: '20000000',
+      decimals: D,
+    })) as any;
+    expect(result.result).toBe('30000000');
+  });
+
+  it('fixed_div via handler', async () => {
+    const result = (await sorobanMath({
+      operation: 'fixed_div',
+      a: '10000000',
+      b: '20000000',
+      decimals: D,
+    })) as any;
+    expect(result.result).toBe('5000000');
+  });
+
+  it('fixed_div by zero re-throws as PulsarValidationError', async () => {
+    await expect(
+      sorobanMath({ operation: 'fixed_div', a: '10000000', b: '0', decimals: D })
+    ).rejects.toThrow('Division by zero');
+  });
+
+  it('mean via handler', async () => {
+    const result = (await sorobanMath({
+      operation: 'mean',
+      values: ['10000000', '30000000'],
+      decimals: D,
+    })) as any;
+    expect(result.result).toBe('20000000');
+  });
+
+  it('weighted_mean via handler', async () => {
+    const result = (await sorobanMath({
+      operation: 'weighted_mean',
+      values: ['10000000', '30000000'],
+      weights: ['30000000', '10000000'],
+      decimals: D,
+    })) as any;
+    expect(result.result).toBe('15000000');
+  });
+
+  it('std_dev via handler', async () => {
+    const result = (await sorobanMath({
+      operation: 'std_dev',
+      values: ['10000000', '30000000'],
+      decimals: D,
+    })) as any;
+    expect(result.result).toBe('10000000');
+  });
+
+  it('twap via handler', async () => {
+    const result = (await sorobanMath({
+      operation: 'twap',
+      prices: [
+        { price: '10000000', timestamp: 0 },
+        { price: '20000000', timestamp: 5 },
+        { price: '30000000', timestamp: 10 },
+      ],
+      decimals: D,
+    })) as any;
+    expect(result.result).toBe('15000000');
+  });
+
+  it('compound_interest via handler', async () => {
+    const result = (await sorobanMath({
+      operation: 'compound_interest',
+      principal: '10000000',
+      rate_bps: 10000,
+      periods: 1,
+      compounds_per_period: 1,
+      decimals: D,
+    })) as any;
+    expect(result.result).toBe('20000000');
+  });
+
+  it('basis_points_to_percent via handler', async () => {
+    const result = (await sorobanMath({
+      operation: 'basis_points_to_percent',
+      value: 500,
+    })) as any;
+    expect(result.result).toBe(5);
+  });
+
+  it('percent_to_basis_points via handler', async () => {
+    const result = (await sorobanMath({
+      operation: 'percent_to_basis_points',
+      value: 5,
+    })) as any;
+    expect(result.result).toBe(500);
+  });
+
+  it('throws PulsarValidationError on invalid input', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(sorobanMath({ operation: 'unknown_op' } as any)).rejects.toThrow();
+  });
+
+  it('throws on invalid BigInt string', async () => {
+    await expect(
+      sorobanMath({ operation: 'fixed_add', a: '1.5', b: '10000000', decimals: D })
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
# Closes #206 

## Feature: `soroban_math` MCP Tool for BigInt-Precision Financial Math

### What Was Implemented

A new `soroban_math` MCP tool that gives AI assistants BigInt-precision math for Soroban financial smart contracts, where token amounts are stored as `i128` integers scaled by `10^7`.

### Why

Soroban contracts can't use floating-point — all amounts are fixed-point integers. AI assistants working with DEX prices, lending rates, or token arithmetic need a way to compute correctly in that integer model without losing precision or pulling in external dependencies.

---

### 📁 Files Created / Modified

| File | Role |
|------|------|
| `src/utils/math.ts` | Pure BigInt math library — fixed-point (`add`/`sub`/`mul`/`div`), statistical (mean, weighted mean, std dev, TWAP), financial (compound interest, basis points), and `formatHumanReadable` |
| `src/tools/soroban_math.ts` | MCP tool handler — type-exhaustive switch over all 11 operations, wraps errors as `PulsarValidationError` |
| `src/schemas/tools.ts` | Appended `SorobanMathInputSchema` — Zod discriminated union covering all 11 operations |
| `src/index.ts` | Added import, tool registration in `ListTools`, and `case 'soroban_math'` in `CallTool` switch |
| `tests/unit/soroban_math.test.ts` | Unit tests — pure computation (no mocks), covers all math functions and all 11 handler cases |
| `README.md` | Added `soroban_math` tool documentation with operation table and examples |

---

### ✅ Checklist

- `npm run lint` — 0 errors, 19 warnings *(all pre-existing in unrelated files, none in new code)*
- `npm run typecheck` — no type errors
- Tests added for all 11 operations, all error branches, and all math functions
- `npm test` — **73 passed**, 11 skipped *(integration tests gated by `RUN_INTEGRATION_TESTS=true`)*
- `README.md` updated with `soroban_math` tool documentation