### PR TITLE
feat: #175 subscription/recurring payment contract

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,28 @@
 #!/usr/bin/env node
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema, ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ErrorCode,
+  McpError,
+} from '@modelcontextprotocol/sdk/types.js';
 
-import { config } from "./config.js";
-import { fetchContractSpec, fetchContractSpecSchema } from "./tools/fetch_contract_spec.js";
+import { config } from './config.js';
+import { fetchContractSpec, fetchContractSpecSchema } from './tools/fetch_contract_spec.js';
 import { submitTransaction } from './tools/submit_transaction.js';
 import { simulateTransaction } from './tools/simulate_transaction.js';
 import { getAccountBalance } from './tools/get_account_balance.js';
 import { computeVestingSchedule } from './tools/compute_vesting_schedule.js';
 import { deployContract } from './tools/deploy_contract.js';
+import { manageSubscription } from './tools/manage_subscription.js';
 import {
   GetAccountBalanceInputSchema,
   SubmitTransactionInputSchema,
   SimulateTransactionInputSchema,
   ComputeVestingScheduleInputSchema,
   DeployContractInputSchema,
+  ManageSubscriptionInputSchema,
 } from './schemas/tools.js';
 import logger from './logger.js';
 import { PulsarError, PulsarNetworkError, PulsarValidationError } from './errors.js';
@@ -38,7 +45,7 @@ class PulsarServer {
         capabilities: {
           tools: {},
         },
-      },
+      }
     );
 
     this.setupHandlers();
@@ -50,7 +57,8 @@ class PulsarServer {
       tools: [
         {
           name: 'get_account_balance',
-          description: 'Get the current XLM and issued asset balances for a Stellar account. Optionally filter by asset code and/or issuer.',
+          description:
+            'Get the current XLM and issued asset balances for a Stellar account. Optionally filter by asset code and/or issuer.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -116,28 +124,29 @@ class PulsarServer {
           },
         },
         {
-          name: "fetch_contract_spec",
+          name: 'fetch_contract_spec',
           description:
-            "Fetch the ABI/interface spec of a deployed Soroban contract. Returns decoded function signatures, parameter types, and emitted event schemas.",
+            'Fetch the ABI/interface spec of a deployed Soroban contract. Returns decoded function signatures, parameter types, and emitted event schemas.',
           inputSchema: {
-            type: "object",
+            type: 'object',
             properties: {
               contract_id: {
-                type: "string",
-                description: "The Soroban contract address (C...)",
+                type: 'string',
+                description: 'The Soroban contract address (C...)',
               },
               network: {
-                type: "string",
-                enum: ["mainnet", "testnet", "futurenet", "custom"],
-                description: "Override the active network for this call.",
+                type: 'string',
+                enum: ['mainnet', 'testnet', 'futurenet', 'custom'],
+                description: 'Override the active network for this call.',
               },
             },
-            required: ["contract_id"],
+            required: ['contract_id'],
           },
         },
         {
           name: 'simulate_transaction',
-          description: 'Simulates a transaction on the Soroban RPC and returns results, footprint, fees, and events.',
+          description:
+            'Simulates a transaction on the Soroban RPC and returns results, footprint, fees, and events.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -156,7 +165,8 @@ class PulsarServer {
         },
         {
           name: 'compute_vesting_schedule',
-          description: 'Calculate a token vesting / timelock release schedule for team, investors, or advisors. Returns released and unreleased amounts plus a period-by-period breakdown.',
+          description:
+            'Calculate a token vesting / timelock release schedule for team, investors, or advisors. Returns released and unreleased amounts plus a period-by-period breakdown.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -210,23 +220,28 @@ class PulsarServer {
               mode: {
                 type: 'string',
                 enum: ['direct', 'factory'],
-                description: "Deployment mode: 'direct' (built-in deployer) or 'factory' (via factory contract)",
+                description:
+                  "Deployment mode: 'direct' (built-in deployer) or 'factory' (via factory contract)",
               },
               source_account: {
                 type: 'string',
-                description: 'Stellar public key (G...) that will deploy the contract and pay fees.',
+                description:
+                  'Stellar public key (G...) that will deploy the contract and pay fees.',
               },
               wasm_hash: {
                 type: 'string',
-                description: 'SHA-256 hash of the uploaded WASM as 64 hex characters. Required for direct mode.',
+                description:
+                  'SHA-256 hash of the uploaded WASM as 64 hex characters. Required for direct mode.',
               },
               salt: {
                 type: 'string',
-                description: 'Optional 32-byte salt as 64 hex characters for deterministic address. Random if omitted.',
+                description:
+                  'Optional 32-byte salt as 64 hex characters for deterministic address. Random if omitted.',
               },
               factory_contract_id: {
                 type: 'string',
-                description: 'Soroban contract ID (C...) of the factory contract. Required for factory mode.',
+                description:
+                  'Soroban contract ID (C...) of the factory contract. Required for factory mode.',
               },
               deploy_function: {
                 type: 'string',
@@ -234,7 +249,8 @@ class PulsarServer {
               },
               deploy_args: {
                 type: 'array',
-                description: "Arguments for factory deploy function as typed SCVal objects. Each item: { type?: 'symbol'|'string'|'u32'|'i32'|'u64'|'i64'|'u128'|'i128'|'bool'|'address'|'bytes'|'void', value: any }",
+                description:
+                  "Arguments for factory deploy function as typed SCVal objects. Each item: { type?: 'symbol'|'string'|'u32'|'i32'|'u64'|'i64'|'u128'|'i128'|'bool'|'address'|'bytes'|'void', value: any }",
               },
               network: {
                 type: 'string',
@@ -243,6 +259,80 @@ class PulsarServer {
               },
             },
             required: ['mode', 'source_account'],
+          },
+        },
+        {
+          name: 'manage_subscription',
+          description:
+            'Compute the current state of a pull-payment recurring subscription between a subscriber and a merchant on the Stellar network. ' +
+            'Returns the subscription status (active / overdue / cancelled / expired / pending), a full billing schedule, amounts collected and outstanding, ' +
+            'and the next payment due date. Use the output to decide when to invoke submit_transaction to pull the next recurring fee. ' +
+            'No network call is made — all computation is deterministic from the supplied plan parameters.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              subscriber: {
+                type: 'string',
+                description: 'Stellar public key (G...) of the subscribing account.',
+              },
+              merchant: {
+                type: 'string',
+                description: 'Stellar public key (G...) of the merchant / service provider.',
+              },
+              amount_per_period: {
+                type: 'number',
+                description: 'Token amount charged per billing period (must be positive).',
+              },
+              asset_code: {
+                type: 'string',
+                description: 'Asset code, e.g. "USDC" or "XLM".',
+              },
+              asset_issuer: {
+                type: 'string',
+                description: 'Issuer public key (G...) for non-native assets. Omit for XLM.',
+              },
+              period_seconds: {
+                type: 'number',
+                description: 'Length of one billing period in seconds, e.g. 2592000 for monthly.',
+              },
+              start_timestamp: {
+                type: 'number',
+                description: 'Unix timestamp (seconds) when the subscription starts.',
+              },
+              total_periods: {
+                type: 'number',
+                description:
+                  'Maximum number of billing periods for fixed-term subscriptions. Omit for indefinite.',
+              },
+              cancelled_timestamp: {
+                type: 'number',
+                description: 'Unix timestamp when the subscriber cancelled. Omit if still active.',
+              },
+              payments_collected: {
+                type: 'number',
+                default: 0,
+                description: 'Number of periods already collected by the merchant (default: 0).',
+              },
+              grace_period_seconds: {
+                type: 'number',
+                default: 0,
+                description:
+                  'Extra seconds after a period due-date before the subscription is marked overdue (default: 0).',
+              },
+              current_timestamp: {
+                type: 'number',
+                description:
+                  'Optional override for current time as Unix timestamp; defaults to wall-clock.',
+              },
+            },
+            required: [
+              'subscriber',
+              'merchant',
+              'amount_per_period',
+              'asset_code',
+              'period_seconds',
+              'start_timestamp',
+            ],
           },
         },
       ],
@@ -258,7 +348,10 @@ class PulsarServer {
           case 'get_account_balance': {
             const parsed = GetAccountBalanceInputSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for get_account_balance`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for get_account_balance`,
+                parsed.error.format()
+              );
             }
             const result = await getAccountBalance(parsed.data);
             return {
@@ -274,16 +367,22 @@ class PulsarServer {
           case 'fetch_contract_spec': {
             const parsed = fetchContractSpecSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for fetch_contract_spec`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for fetch_contract_spec`,
+                parsed.error.format()
+              );
             }
             const result = await fetchContractSpec(parsed.data);
-            return { content: [{ type: "text", text: JSON.stringify(result) }] };
+            return { content: [{ type: 'text', text: JSON.stringify(result) }] };
           }
 
           case 'submit_transaction': {
             const parsed = SubmitTransactionInputSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for submit_transaction`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for submit_transaction`,
+                parsed.error.format()
+              );
             }
             const result = await submitTransaction(parsed.data);
             return {
@@ -294,7 +393,10 @@ class PulsarServer {
           case 'simulate_transaction': {
             const parsed = SimulateTransactionInputSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for simulate_transaction`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for simulate_transaction`,
+                parsed.error.format()
+              );
             }
             const result = await simulateTransaction(parsed.data);
             return {
@@ -305,7 +407,10 @@ class PulsarServer {
           case 'compute_vesting_schedule': {
             const parsed = ComputeVestingScheduleInputSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for compute_vesting_schedule`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for compute_vesting_schedule`,
+                parsed.error.format()
+              );
             }
             const result = await computeVestingSchedule(parsed.data);
             return {
@@ -316,9 +421,26 @@ class PulsarServer {
           case 'deploy_contract': {
             const parsed = DeployContractInputSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for deploy_contract`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for deploy_contract`,
+                parsed.error.format()
+              );
             }
             const result = await deployContract(parsed.data);
+            return {
+              content: [{ type: 'text', text: JSON.stringify(result) }],
+            };
+          }
+
+          case 'manage_subscription': {
+            const parsed = ManageSubscriptionInputSchema.safeParse(args);
+            if (!parsed.success) {
+              throw new PulsarValidationError(
+                `Invalid input for manage_subscription`,
+                parsed.error.format()
+              );
+            }
+            const result = await manageSubscription(parsed.data);
             return {
               content: [{ type: 'text', text: JSON.stringify(result) }],
             };
@@ -343,10 +465,9 @@ class PulsarServer {
       throw error;
     } else {
       // Convert unknown errors to PulsarNetworkError as per requirements
-      pulsarError = new PulsarNetworkError(
-        error instanceof Error ? error.message : String(error),
-        { originalError: error }
-      );
+      pulsarError = new PulsarNetworkError(error instanceof Error ? error.message : String(error), {
+        originalError: error,
+      });
     }
 
     logger.error(
@@ -384,9 +505,7 @@ class PulsarServer {
   async run() {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    logger.info(
-      `pulsar MCP server v1.0.0 is running on ${config.stellarNetwork}...`,
-    );
+    logger.info(`pulsar MCP server v1.0.0 is running on ${config.stellarNetwork}...`);
   }
 }
 
@@ -395,4 +514,3 @@ pulsar.run().catch((error) => {
   logger.fatal({ error }, '❌ Fatal error in pulsar server');
   process.exit(1);
 });
-

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -6,21 +6,21 @@
  * before any RPC calls are made.
  */
 
-import { z } from "zod";
+import { z } from 'zod';
 
 import {
   StellarPublicKeySchema,
   ContractIdSchema,
   XdrBase64Schema,
   NetworkSchema,
-} from "./index.js";
+} from './index.js';
 
 const Hex32Schema = z
   .string()
   .regex(/^[a-fA-F0-9]{64}$/, {
-    message: "Must be a 64-character hex string (32 bytes)",
+    message: 'Must be a 64-character hex string (32 bytes)',
   })
-  .describe("32-byte value encoded as 64 hex characters");
+  .describe('32-byte value encoded as 64 hex characters');
 
 /**
  * Schema for get_account_balance tool
@@ -36,9 +36,7 @@ export const GetAccountBalanceInputSchema = z.object({
   asset_issuer: StellarPublicKeySchema.optional(),
 });
 
-export type GetAccountBalanceInput = z.infer<
-  typeof GetAccountBalanceInputSchema
->;
+export type GetAccountBalanceInput = z.infer<typeof GetAccountBalanceInputSchema>;
 
 /**
  * Schema for submit_transaction tool
@@ -58,14 +56,12 @@ export const SubmitTransactionInputSchema = z.object({
   wait_timeout_ms: z
     .number()
     .int()
-    .min(1000, { message: "wait_timeout_ms must be at least 1000 ms" })
-    .max(120_000, { message: "wait_timeout_ms must not exceed 120000 ms" })
+    .min(1000, { message: 'wait_timeout_ms must be at least 1000 ms' })
+    .max(120_000, { message: 'wait_timeout_ms must not exceed 120000 ms' })
     .default(30_000),
 });
 
-export type SubmitTransactionInput = z.infer<
-  typeof SubmitTransactionInputSchema
->;
+export type SubmitTransactionInput = z.infer<typeof SubmitTransactionInputSchema>;
 
 /**
  * Schema for potential future contract_read tool.
@@ -75,9 +71,9 @@ export const ContractReadInputSchema = z.object({
   contract_id: ContractIdSchema,
   method: z
     .string()
-    .min(1, { message: "Method name cannot be empty" })
+    .min(1, { message: 'Method name cannot be empty' })
     .regex(/^[a-zA-Z_][a-zA-Z0-9_]*$/, {
-      message: "Method name must be a valid identifier",
+      message: 'Method name must be a valid identifier',
     }),
   args: z.record(z.unknown()).optional(),
 });
@@ -96,9 +92,7 @@ export const SimulateTransactionInputSchema = z.object({
   network: NetworkSchema.optional(),
 });
 
-export type SimulateTransactionInput = z.infer<
-  typeof SimulateTransactionInputSchema
->;
+export type SimulateTransactionInput = z.infer<typeof SimulateTransactionInputSchema>;
 
 /**
  * Schema for compute_vesting_schedule tool
@@ -113,39 +107,32 @@ export type SimulateTransactionInput = z.infer<
  * - current_timestamp: Optional override for "now" (defaults to current time)
  */
 export const ComputeVestingScheduleInputSchema = z.object({
-  total_amount: z
-    .number()
-    .positive({ message: "total_amount must be positive" }),
+  total_amount: z.number().positive({ message: 'total_amount must be positive' }),
   start_timestamp: z
     .number()
     .int()
-    .positive({ message: "start_timestamp must be a positive Unix timestamp" }),
-  cliff_seconds: z
-    .number()
-    .int()
-    .nonnegative({ message: "cliff_seconds must be non-negative" }),
+    .positive({ message: 'start_timestamp must be a positive Unix timestamp' }),
+  cliff_seconds: z.number().int().nonnegative({ message: 'cliff_seconds must be non-negative' }),
   vesting_duration_seconds: z
     .number()
     .int()
-    .positive({ message: "vesting_duration_seconds must be positive" }),
+    .positive({ message: 'vesting_duration_seconds must be positive' }),
   release_frequency_seconds: z
     .number()
     .int()
-    .positive({ message: "release_frequency_seconds must be positive" }),
+    .positive({ message: 'release_frequency_seconds must be positive' }),
   beneficiary_type: z
-    .enum(["team", "investor", "advisor", "other"])
-    .describe("Type of beneficiary receiving the vesting tokens"),
+    .enum(['team', 'investor', 'advisor', 'other'])
+    .describe('Type of beneficiary receiving the vesting tokens'),
   current_timestamp: z
     .number()
     .int()
     .positive()
     .optional()
-    .describe("Optional override for current time as Unix timestamp"),
+    .describe('Optional override for current time as Unix timestamp'),
 });
 
-export type ComputeVestingScheduleInput = z.infer<
-  typeof ComputeVestingScheduleInputSchema
->;
+export type ComputeVestingScheduleInput = z.infer<typeof ComputeVestingScheduleInputSchema>;
 
 /**
  * Schema for deploy_contract tool
@@ -166,19 +153,19 @@ export type ComputeVestingScheduleInput = z.infer<
  */
 export const DeployContractInputSchema = z.object({
   mode: z
-    .enum(["direct", "factory"])
-    .describe("Deployment mode: direct (built-in deployer) or factory (via factory contract)"),
+    .enum(['direct', 'factory'])
+    .describe('Deployment mode: direct (built-in deployer) or factory (via factory contract)'),
   source_account: StellarPublicKeySchema.describe(
-    "The Stellar account that will deploy the contract and pay fees"
+    'The Stellar account that will deploy the contract and pay fees'
   ),
   wasm_hash: Hex32Schema.optional().describe(
-    "SHA-256 hash of the uploaded WASM (64 hex chars). Required for direct mode."
+    'SHA-256 hash of the uploaded WASM (64 hex chars). Required for direct mode.'
   ),
   salt: Hex32Schema.optional().describe(
-    "Optional 32-byte salt for deterministic contract address (64 hex chars). Random if omitted."
+    'Optional 32-byte salt for deterministic contract address (64 hex chars). Random if omitted.'
   ),
   factory_contract_id: ContractIdSchema.optional().describe(
-    "Factory contract ID. Required for factory mode."
+    'Factory contract ID. Required for factory mode.'
   ),
   deploy_function: z
     .string()
@@ -190,28 +177,114 @@ export const DeployContractInputSchema = z.object({
       z.object({
         type: z
           .enum([
-            "symbol",
-            "string",
-            "u32",
-            "i32",
-            "u64",
-            "i64",
-            "u128",
-            "i128",
-            "bool",
-            "address",
-            "bytes",
-            "void",
+            'symbol',
+            'string',
+            'u32',
+            'i32',
+            'u64',
+            'i64',
+            'u128',
+            'i128',
+            'bool',
+            'address',
+            'bytes',
+            'void',
           ])
           .optional()
-          .describe("Soroban SCVal type hint"),
-        value: z.unknown().describe("The value to convert to SCVal"),
+          .describe('Soroban SCVal type hint'),
+        value: z.unknown().describe('The value to convert to SCVal'),
       })
     )
     .optional()
-    .describe("Arguments for factory deploy function as typed SCVal objects"),
+    .describe('Arguments for factory deploy function as typed SCVal objects'),
   network: NetworkSchema.optional(),
 });
 
 export type DeployContractInput = z.infer<typeof DeployContractInputSchema>;
 
+// ---------------------------------------------------------------------------
+// manage_subscription
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for manage_subscription tool (Issue #175 — pull-payment model)
+ *
+ * Models a recurring pull-payment subscription between a subscriber and a
+ * merchant on the Stellar network.  All timestamps are Unix seconds.
+ *
+ * Inputs:
+ * - subscriber:              Stellar public key of the payer
+ * - merchant:                Stellar public key of the payee / service provider
+ * - amount_per_period:       Token amount charged each billing period (> 0)
+ * - asset_code:              Asset code (e.g. "USDC", "XLM")
+ * - asset_issuer:            Issuer public key; omit for XLM
+ * - period_seconds:          Length of one billing period in seconds (> 0)
+ * - start_timestamp:         Unix timestamp when the subscription begins
+ * - total_periods:           Max periods before subscription expires; omit for indefinite
+ * - cancelled_timestamp:     Unix timestamp when subscriber cancelled; omit if still active
+ * - payments_collected:      Number of periods already collected by merchant (≥ 0)
+ * - grace_period_seconds:    Extra seconds after a period ends before marking overdue (≥ 0)
+ * - current_timestamp:       Optional override for "now"; defaults to wall-clock
+ */
+export const ManageSubscriptionInputSchema = z.object({
+  subscriber: StellarPublicKeySchema.describe(
+    'Stellar public key (G...) of the subscribing account'
+  ),
+  merchant: StellarPublicKeySchema.describe(
+    'Stellar public key (G...) of the merchant / service provider'
+  ),
+  amount_per_period: z
+    .number()
+    .positive({ message: 'amount_per_period must be positive' })
+    .describe('Token amount charged per billing period'),
+  asset_code: z
+    .string()
+    .min(1, { message: 'asset_code cannot be empty' })
+    .max(12, { message: 'asset_code must be at most 12 characters' })
+    .describe('Asset code, e.g. USDC or XLM'),
+  asset_issuer: StellarPublicKeySchema.optional().describe(
+    'Issuer public key (G...) for non-native assets; omit for XLM'
+  ),
+  period_seconds: z
+    .number()
+    .int()
+    .positive({ message: 'period_seconds must be a positive integer' })
+    .describe('Length of one billing period in seconds'),
+  start_timestamp: z
+    .number()
+    .int()
+    .positive({ message: 'start_timestamp must be a positive Unix timestamp' })
+    .describe('Unix timestamp (seconds) when the subscription starts'),
+  total_periods: z
+    .number()
+    .int()
+    .positive({ message: 'total_periods must be a positive integer' })
+    .optional()
+    .describe('Maximum number of billing periods; omit for indefinite subscriptions'),
+  cancelled_timestamp: z
+    .number()
+    .int()
+    .positive({ message: 'cancelled_timestamp must be a positive Unix timestamp' })
+    .optional()
+    .describe('Unix timestamp when the subscriber cancelled; omit if still active'),
+  payments_collected: z
+    .number()
+    .int()
+    .nonnegative({ message: 'payments_collected must be non-negative' })
+    .default(0)
+    .describe('Number of billing periods already collected by the merchant'),
+  grace_period_seconds: z
+    .number()
+    .int()
+    .nonnegative({ message: 'grace_period_seconds must be non-negative' })
+    .default(0)
+    .describe('Extra seconds after a period due-date before the subscription is marked overdue'),
+  current_timestamp: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Optional override for current time as Unix timestamp; defaults to wall-clock'),
+});
+
+export type ManageSubscriptionInput = z.infer<typeof ManageSubscriptionInputSchema>;

--- a/src/tools/manage_subscription.ts
+++ b/src/tools/manage_subscription.ts
@@ -1,0 +1,276 @@
+/**
+ * Tool: manage_subscription
+ *
+ * Implements a pull-payment model for recurring service fees on
+ * the Stellar / Soroban network (Issue #175).
+ *
+ * This is a pure-computation tool — it derives subscription state from plan
+ * parameters without hitting any network endpoint.  The output is intended to
+ * be fed into simulate_transaction / submit_transaction when the merchant
+ * wants to actually collect a payment.
+ *
+ * Pull-payment semantics
+ * ─────────────────────
+ * • The merchant (payee) initiates each payment collection, not the subscriber.
+ * • Payments become collectable at the start of each new period.
+ * • An optional grace_period_seconds window exists after each due-date before
+ *   the subscription is marked OVERDUE.
+ * • A cancelled subscription stops generating new collectible periods after
+ *   the cancellation date.
+ * • A fixed-term subscription expires automatically after total_periods.
+ */
+
+import { ManageSubscriptionInputSchema } from '../schemas/tools.js';
+import { PulsarValidationError } from '../errors.js';
+import type { McpToolHandler } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Public output types
+// ---------------------------------------------------------------------------
+
+/** Status of the subscription at the evaluated timestamp. */
+export type SubscriptionStatus =
+  | 'active' // within a valid paid period, not overdue
+  | 'overdue' // payment is past due (grace elapsed) but subscription not cancelled
+  | 'cancelled' // subscriber cancelled; no further charges
+  | 'expired' // fixed-term subscription fully elapsed
+  | 'pending'; // before the first period has started
+
+/** Representation of a single billing period in the schedule. */
+export interface SubscriptionPeriod {
+  /** Period number (1-based). */
+  period: number;
+  /** ISO-8601 date when this period becomes due (start of the billing interval). */
+  due_date: string;
+  /** ISO-8601 date when the grace window closes for this period. */
+  grace_ends: string;
+  /** Whether the merchant has already collected this period's payment. */
+  collected: boolean;
+  /** Whether this period is currently overdue (grace elapsed, not yet collected). */
+  overdue: boolean;
+}
+
+/** Full output returned by manage_subscription. */
+export interface ManageSubscriptionOutput {
+  /** Evaluated subscription status. */
+  status: SubscriptionStatus;
+  /** Subscriber public key. */
+  subscriber: string;
+  /** Merchant public key. */
+  merchant: string;
+  /** Human-readable asset identifier, e.g. "USDC:G…" or "XLM". */
+  asset: string;
+  /** Amount charged per billing period (7 decimal places). */
+  amount_per_period: string;
+  /** Length of one billing period in seconds. */
+  period_seconds: number;
+  /** ISO-8601 subscription start date. */
+  start_date: string;
+  /** ISO-8601 subscription end date, or null for indefinite subscriptions. */
+  end_date: string | null;
+  /** ISO-8601 cancellation date, or null if not cancelled. */
+  cancelled_date: string | null;
+  /** Number of periods already collected by the merchant. */
+  payments_collected: number;
+  /** Number of periods that are due but not yet collected. */
+  payments_outstanding: number;
+  /** Total token amount already collected (7 decimal places). */
+  total_collected_amount: string;
+  /** Total token amount outstanding across all uncollected due periods (7 decimal places). */
+  total_outstanding_amount: string;
+  /** ISO-8601 due date of the next uncollected period, or null if none. */
+  next_payment_due: string | null;
+  /** ISO-8601 timestamp of the last collected payment, or null if none. */
+  last_payment_date: string | null;
+  /** ISO-8601 end of grace window for the oldest overdue period, or null. */
+  grace_period_ends: string | null;
+  /** Full billing schedule up to the current evaluation point. */
+  schedule: SubscriptionPeriod[];
+}
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export const manageSubscription: McpToolHandler<typeof ManageSubscriptionInputSchema> = async (
+  input: unknown
+): Promise<ManageSubscriptionOutput> => {
+  // ── 1. Validate inputs ────────────────────────────────────────────────────
+  const parsed = ManageSubscriptionInputSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new PulsarValidationError('Invalid input for manage_subscription', parsed.error.format());
+  }
+
+  const {
+    subscriber,
+    merchant,
+    amount_per_period,
+    asset_code,
+    asset_issuer,
+    period_seconds,
+    start_timestamp,
+    total_periods,
+    cancelled_timestamp,
+    payments_collected,
+    grace_period_seconds,
+    current_timestamp,
+  } = parsed.data;
+
+  // ── 2. Cross-field validation ─────────────────────────────────────────────
+  if (subscriber === merchant) {
+    throw new PulsarValidationError('subscriber and merchant must be different Stellar accounts');
+  }
+
+  if (cancelled_timestamp !== undefined && cancelled_timestamp < start_timestamp) {
+    throw new PulsarValidationError('cancelled_timestamp must be after start_timestamp');
+  }
+
+  const now = current_timestamp ?? Math.floor(Date.now() / 1000);
+
+  if (now < start_timestamp) {
+    // Subscription hasn't started yet — return a minimal pending response.
+    const asset = buildAssetLabel(asset_code, asset_issuer);
+    const endDate =
+      total_periods != null
+        ? new Date((start_timestamp + total_periods * period_seconds) * 1000).toISOString()
+        : null;
+
+    return {
+      status: 'pending',
+      subscriber,
+      merchant,
+      asset,
+      amount_per_period: amount_per_period.toFixed(7),
+      period_seconds,
+      start_date: new Date(start_timestamp * 1000).toISOString(),
+      end_date: endDate,
+      cancelled_date: null,
+      payments_collected: 0,
+      payments_outstanding: 0,
+      total_collected_amount: (0).toFixed(7),
+      total_outstanding_amount: (0).toFixed(7),
+      next_payment_due: new Date(start_timestamp * 1000).toISOString(),
+      last_payment_date: null,
+      grace_period_ends: null,
+      schedule: [],
+    };
+  }
+
+  // ── 3. Derive how many periods have elapsed ───────────────────────────────
+  const elapsed = now - start_timestamp;
+  // Number of complete billing periods elapsed since start
+  let periodsElapsed = Math.floor(elapsed / period_seconds);
+
+  // Cap to total_periods for fixed-term subscriptions
+  if (total_periods != null) {
+    periodsElapsed = Math.min(periodsElapsed, total_periods);
+  }
+
+  // If cancelled: only periods up to (and including) the period containing the
+  // cancellation date are ever collectible.
+  const effectiveCancelPeriod =
+    cancelled_timestamp !== undefined
+      ? Math.min(
+          Math.ceil((cancelled_timestamp - start_timestamp) / period_seconds),
+          total_periods ?? Infinity
+        )
+      : null;
+
+  const maxCollectiblePeriods =
+    effectiveCancelPeriod != null
+      ? Math.min(periodsElapsed, effectiveCancelPeriod)
+      : periodsElapsed;
+
+  // ── 4. Build the schedule ─────────────────────────────────────────────────
+  const schedule: SubscriptionPeriod[] = [];
+
+  for (let i = 1; i <= maxCollectiblePeriods; i++) {
+    const dueDateTs = start_timestamp + (i - 1) * period_seconds;
+    const graceEndsTs = dueDateTs + grace_period_seconds;
+    const isCollected = i <= payments_collected;
+    const isOverdue = !isCollected && now > graceEndsTs;
+
+    schedule.push({
+      period: i,
+      due_date: new Date(dueDateTs * 1000).toISOString(),
+      grace_ends: new Date(graceEndsTs * 1000).toISOString(),
+      collected: isCollected,
+      overdue: isOverdue,
+    });
+  }
+
+  // ── 5. Aggregate metrics ──────────────────────────────────────────────────
+  const collectibleCount = schedule.length;
+  const actualCollected = Math.min(payments_collected, collectibleCount);
+  const outstanding = collectibleCount - actualCollected;
+
+  const totalCollected = actualCollected * amount_per_period;
+  const totalOutstanding = outstanding * amount_per_period;
+
+  // Next uncollected period due date
+  const nextPeriod = schedule.find((p) => !p.collected);
+  const nextPaymentDue = nextPeriod?.due_date ?? null;
+
+  // Last collected payment date
+  const lastCollectedPeriod = [...schedule].reverse().find((p) => p.collected);
+  const lastPaymentDate = lastCollectedPeriod?.due_date ?? null;
+
+  // Oldest overdue grace end
+  const oldestOverdue = schedule.find((p) => p.overdue);
+  const gracePeriodEnds = oldestOverdue?.grace_ends ?? null;
+
+  // ── 6. Determine status ───────────────────────────────────────────────────
+  const asset = buildAssetLabel(asset_code, asset_issuer);
+
+  const endTimestamp =
+    total_periods != null ? start_timestamp + total_periods * period_seconds : null;
+  const endDate = endTimestamp != null ? new Date(endTimestamp * 1000).toISOString() : null;
+  const cancelledDate =
+    cancelled_timestamp != null ? new Date(cancelled_timestamp * 1000).toISOString() : null;
+
+  let status: SubscriptionStatus;
+
+  if (cancelled_timestamp !== undefined && now >= cancelled_timestamp) {
+    status = 'cancelled';
+  } else if (endTimestamp != null && now >= endTimestamp) {
+    status = 'expired';
+  } else if (oldestOverdue != null) {
+    status = 'overdue';
+  } else {
+    status = 'active';
+  }
+
+  // ── 7. Return result ──────────────────────────────────────────────────────
+  return {
+    status,
+    subscriber,
+    merchant,
+    asset,
+    amount_per_period: amount_per_period.toFixed(7),
+    period_seconds,
+    start_date: new Date(start_timestamp * 1000).toISOString(),
+    end_date: endDate,
+    cancelled_date: cancelledDate,
+    payments_collected: actualCollected,
+    payments_outstanding: outstanding,
+    total_collected_amount: totalCollected.toFixed(7),
+    total_outstanding_amount: totalOutstanding.toFixed(7),
+    next_payment_due: nextPaymentDue,
+    last_payment_date: lastPaymentDate,
+    grace_period_ends: gracePeriodEnds,
+    schedule,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a human-readable asset label for display in tool output.
+ * e.g. "USDC:GABC…" for issued assets, or "XLM" for the native asset.
+ */
+function buildAssetLabel(code: string, issuer?: string): string {
+  if (issuer) return `${code}:${issuer}`;
+  return code;
+}

--- a/tests/integration/manage_subscription.test.ts
+++ b/tests/integration/manage_subscription.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Integration tests for manage_subscription tool (Issue #175)
+ *
+ * These tests exercise the full computation pipeline with wall-clock
+ * timestamps (no deterministic fixture epoch).  No network calls are
+ * required — manage_subscription is a pure-computation tool.
+ *
+ * Scenarios:
+ *  - Active monthly SaaS subscription started 3 months ago, 2 collected
+ *  - Overdue subscription with no collections and no grace period
+ *  - Cancelled subscription — schedule stops at cancellation
+ *  - Expired fixed-term subscription (12-month, 12 collected)
+ *  - Indefinite subscription that's pending (starts in the future)
+ *  - Weekly billing with partial collection
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { manageSubscription } from '../../src/tools/manage_subscription.js';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const SUBSCRIBER = 'GABC1234ABCD5678ABCD1234ABCD5678ABCD1234ABCD5678ABCD5678ABCD';
+const MERCHANT = 'GDEF1234ABCD5678ABCD1234ABCD5678ABCD1234ABCD5678ABCD5678ABCD';
+const ISSUER = 'GHIJ1234ABCD5678ABCD1234ABCD5678ABCD1234ABCD5678ABCD5678ABCD';
+
+const now = Math.floor(Date.now() / 1000);
+const MONTHLY = 2_592_000; // 30 days
+const WEEKLY = 604_800; // 7 days
+
+describe('manage_subscription (Integration)', () => {
+  // ── Active monthly SaaS subscription ──────────────────────────────────────
+  it('active monthly subscription with 2 of 3 periods collected', async () => {
+    const start = now - 3 * MONTHLY - 1; // 3 full periods elapsed
+
+    const result = (await manageSubscription({
+      subscriber: SUBSCRIBER,
+      merchant: MERCHANT,
+      amount_per_period: 29.99,
+      asset_code: 'USDC',
+      asset_issuer: ISSUER,
+      period_seconds: MONTHLY,
+      start_timestamp: start,
+      payments_collected: 2,
+      grace_period_seconds: 86_400, // 1-day grace
+    })) as any;
+
+    expect(result.status).toBe('active'); // period 3 within grace
+    expect(result.payments_collected).toBe(2);
+    expect(result.payments_outstanding).toBe(1);
+    expect(parseFloat(result.total_collected_amount)).toBeCloseTo(2 * 29.99, 5);
+    expect(parseFloat(result.total_outstanding_amount)).toBeCloseTo(1 * 29.99, 5);
+    expect(result.schedule).toHaveLength(3);
+    expect(result.schedule[0].collected).toBe(true);
+    expect(result.schedule[1].collected).toBe(true);
+    expect(result.schedule[2].collected).toBe(false);
+    expect(result.asset).toBe(`USDC:${ISSUER}`);
+    expect(result.end_date).toBeNull();
+  });
+
+  // ── Overdue — no grace, no collections ───────────────────────────────────
+  it('marks subscription as overdue when payment is due with zero grace', async () => {
+    const start = now - 2 * MONTHLY - 1; // 2 periods elapsed
+
+    const result = (await manageSubscription({
+      subscriber: SUBSCRIBER,
+      merchant: MERCHANT,
+      amount_per_period: 9.99,
+      asset_code: 'XLM',
+      period_seconds: MONTHLY,
+      start_timestamp: start,
+      payments_collected: 0,
+      grace_period_seconds: 0,
+    })) as any;
+
+    expect(result.status).toBe('overdue');
+    expect(result.payments_outstanding).toBe(2);
+    expect(result.schedule.every((p: any) => p.overdue)).toBe(true);
+    expect(result.grace_period_ends).not.toBeNull();
+  });
+
+  // ── Cancelled subscription ────────────────────────────────────────────────
+  it('returns cancelled status and truncated schedule after cancellation', async () => {
+    const start = now - 4 * MONTHLY - 1;
+    const cancelledAt = now - 2 * MONTHLY; // cancelled 2 months ago
+
+    const result = (await manageSubscription({
+      subscriber: SUBSCRIBER,
+      merchant: MERCHANT,
+      amount_per_period: 49,
+      asset_code: 'USDC',
+      asset_issuer: ISSUER,
+      period_seconds: MONTHLY,
+      start_timestamp: start,
+      cancelled_timestamp: cancelledAt,
+      payments_collected: 1,
+      grace_period_seconds: 0,
+    })) as any;
+
+    expect(result.status).toBe('cancelled');
+    expect(result.cancelled_date).toBe(new Date(cancelledAt * 1000).toISOString());
+    // Schedule should not extend beyond the cancellation window
+    expect(result.schedule.length).toBeLessThan(4);
+  });
+
+  // ── Expired fixed-term subscription ──────────────────────────────────────
+  it('expires a 12-month fixed-term subscription after full term', async () => {
+    const start = now - 13 * MONTHLY; // 13 months ago
+
+    const result = (await manageSubscription({
+      subscriber: SUBSCRIBER,
+      merchant: MERCHANT,
+      amount_per_period: 19.99,
+      asset_code: 'USDC',
+      asset_issuer: ISSUER,
+      period_seconds: MONTHLY,
+      start_timestamp: start,
+      total_periods: 12,
+      payments_collected: 12,
+      grace_period_seconds: 0,
+    })) as any;
+
+    expect(result.status).toBe('expired');
+    expect(result.schedule).toHaveLength(12);
+    expect(result.payments_outstanding).toBe(0);
+    expect(result.end_date).toBe(new Date((start + 12 * MONTHLY) * 1000).toISOString());
+  });
+
+  // ── Pending — starts in the future ───────────────────────────────────────
+  it('returns pending for a subscription that has not yet started', async () => {
+    const start = now + MONTHLY; // starts next month
+
+    const result = (await manageSubscription({
+      subscriber: SUBSCRIBER,
+      merchant: MERCHANT,
+      amount_per_period: 5,
+      asset_code: 'XLM',
+      period_seconds: MONTHLY,
+      start_timestamp: start,
+      payments_collected: 0,
+      grace_period_seconds: 0,
+    })) as any;
+
+    expect(result.status).toBe('pending');
+    expect(result.schedule).toHaveLength(0);
+    expect(result.payments_outstanding).toBe(0);
+    expect(result.next_payment_due).toBe(new Date(start * 1000).toISOString());
+  });
+
+  // ── Weekly billing ────────────────────────────────────────────────────────
+  it('computes correct weekly billing with partial collection', async () => {
+    const start = now - 5 * WEEKLY - 1; // 5 full weeks elapsed
+
+    const result = (await manageSubscription({
+      subscriber: SUBSCRIBER,
+      merchant: MERCHANT,
+      amount_per_period: 7,
+      asset_code: 'XLM',
+      period_seconds: WEEKLY,
+      start_timestamp: start,
+      payments_collected: 3,
+      grace_period_seconds: 3_600, // 1-hour grace
+    })) as any;
+
+    expect(result.schedule).toHaveLength(5);
+    expect(result.payments_collected).toBe(3);
+    expect(result.payments_outstanding).toBe(2);
+    expect(parseFloat(result.total_collected_amount)).toBeCloseTo(3 * 7, 5);
+    expect(parseFloat(result.total_outstanding_amount)).toBeCloseTo(2 * 7, 5);
+  });
+
+  // ── Output shape invariants ───────────────────────────────────────────────
+  it('always includes all required output fields', async () => {
+    const start = now - MONTHLY - 1;
+
+    const result = (await manageSubscription({
+      subscriber: SUBSCRIBER,
+      merchant: MERCHANT,
+      amount_per_period: 1,
+      asset_code: 'XLM',
+      period_seconds: MONTHLY,
+      start_timestamp: start,
+      payments_collected: 0,
+      grace_period_seconds: 0,
+    })) as any;
+
+    const requiredFields = [
+      'status',
+      'subscriber',
+      'merchant',
+      'asset',
+      'amount_per_period',
+      'period_seconds',
+      'start_date',
+      'end_date',
+      'cancelled_date',
+      'payments_collected',
+      'payments_outstanding',
+      'total_collected_amount',
+      'total_outstanding_amount',
+      'next_payment_due',
+      'last_payment_date',
+      'grace_period_ends',
+      'schedule',
+    ];
+
+    for (const field of requiredFields) {
+      expect(result).toHaveProperty(field);
+    }
+  });
+});

--- a/tests/unit/manage_subscription.test.ts
+++ b/tests/unit/manage_subscription.test.ts
@@ -1,0 +1,541 @@
+/**
+ * Unit tests for manage_subscription tool (Issue #175)
+ *
+ * Covers:
+ *  - pending status (before start)
+ *  - active status (within a paid period)
+ *  - overdue status (grace elapsed, uncollected)
+ *  - cancelled status
+ *  - expired status (fixed-term complete)
+ *  - payment schedule correctness
+ *  - partial collection by merchant
+ *  - indefinite vs fixed-term subscriptions
+ *  - grace period boundary conditions
+ *  - input validation errors
+ *  - asset label formatting (native XLM and issued assets)
+ *  - subscriber === merchant guard
+ *  - cancelled_timestamp before start_timestamp guard
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { manageSubscription } from '../../src/tools/manage_subscription.js';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const SUBSCRIBER = 'GABC1234ABCD5678ABCD1234ABCD5678ABCD1234ABCD5678ABCD5678ABCD';
+const MERCHANT = 'GDEF1234ABCD5678ABCD1234ABCD5678ABCD1234ABCD5678ABCD5678ABCD';
+const ISSUER = 'GHIJ1234ABCD5678ABCD1234ABCD5678ABCD1234ABCD5678ABCD5678ABCD';
+
+// Fixed epoch to make all tests deterministic
+const BASE_TIME = 1_700_000_000; // 2023-11-14 22:13:20 UTC
+const MONTHLY = 2_592_000; // 30 days in seconds
+const DAILY = 86_400; // 1 day in seconds
+
+/** Convenience builder — only overrides what the test needs. */
+function makeInput(overrides: Record<string, unknown> = {}) {
+  return {
+    subscriber: SUBSCRIBER,
+    merchant: MERCHANT,
+    amount_per_period: 100,
+    asset_code: 'USDC',
+    asset_issuer: ISSUER,
+    period_seconds: MONTHLY,
+    start_timestamp: BASE_TIME,
+    payments_collected: 0,
+    grace_period_seconds: 0,
+    ...overrides,
+  };
+}
+
+// ── Status: pending ──────────────────────────────────────────────────────────
+
+describe('status: pending', () => {
+  it('returns pending when current time is before start', async () => {
+    const result = (await manageSubscription(
+      makeInput({ current_timestamp: BASE_TIME - 1 })
+    )) as any;
+
+    expect(result.status).toBe('pending');
+    expect(result.payments_collected).toBe(0);
+    expect(result.payments_outstanding).toBe(0);
+    expect(result.schedule).toHaveLength(0);
+    expect(result.next_payment_due).toBe(new Date(BASE_TIME * 1000).toISOString());
+  });
+
+  it('returns pending with correct end_date for fixed-term subscription', async () => {
+    const result = (await manageSubscription(
+      makeInput({ current_timestamp: BASE_TIME - 1, total_periods: 3 })
+    )) as any;
+
+    expect(result.status).toBe('pending');
+    expect(result.end_date).toBe(new Date((BASE_TIME + 3 * MONTHLY) * 1000).toISOString());
+  });
+
+  it('returns null end_date for indefinite subscription when pending', async () => {
+    const result = (await manageSubscription(
+      makeInput({ current_timestamp: BASE_TIME - 100 })
+    )) as any;
+
+    expect(result.end_date).toBeNull();
+  });
+});
+
+// ── Status: active ───────────────────────────────────────────────────────────
+
+describe('status: active', () => {
+  it('is active just after start with no periods elapsed', async () => {
+    // 1 second into the first period — period 1 is due but within grace (grace=0 so it should be overdue only after grace elapses)
+    // At exactly start_timestamp + 0 seconds: periodsElapsed = 0, so no periods in schedule yet
+    const result = (await manageSubscription(makeInput({ current_timestamp: BASE_TIME }))) as any;
+
+    // elapsed = 0 → periodsElapsed = 0 → no schedule entries
+    expect(result.status).toBe('active');
+    expect(result.schedule).toHaveLength(0);
+    expect(result.payments_outstanding).toBe(0);
+  });
+
+  it('is active when all due periods have been collected', async () => {
+    // 2 full periods elapsed, both collected
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + 2 * MONTHLY + 1,
+        payments_collected: 2,
+      })
+    )) as any;
+
+    expect(result.status).toBe('active');
+    expect(result.payments_outstanding).toBe(0);
+    expect(result.schedule).toHaveLength(2);
+    expect(result.schedule.every((p: any) => p.collected)).toBe(true);
+  });
+
+  it('next_payment_due points to the first uncollected period', async () => {
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + 3 * MONTHLY + 1,
+        payments_collected: 2,
+      })
+    )) as any;
+
+    // 3 periods elapsed; 2 collected → period 3 is outstanding
+    const expectedDue = new Date((BASE_TIME + 2 * MONTHLY) * 1000).toISOString();
+    expect(result.next_payment_due).toBe(expectedDue);
+  });
+
+  it('last_payment_date reflects the most recently collected period', async () => {
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + 3 * MONTHLY + 1,
+        payments_collected: 2,
+      })
+    )) as any;
+
+    // Period 2 due date = BASE_TIME + 1 * MONTHLY
+    const expected = new Date((BASE_TIME + 1 * MONTHLY) * 1000).toISOString();
+    expect(result.last_payment_date).toBe(expected);
+  });
+
+  it('last_payment_date is null when nothing collected', async () => {
+    const result = (await manageSubscription(
+      makeInput({ current_timestamp: BASE_TIME + MONTHLY + 1 })
+    )) as any;
+
+    expect(result.last_payment_date).toBeNull();
+  });
+});
+
+// ── Status: overdue ──────────────────────────────────────────────────────────
+
+describe('status: overdue', () => {
+  it('is overdue when a period is uncollected and grace has elapsed', async () => {
+    // 1 period elapsed, grace=0 → immediately overdue
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + MONTHLY + 1,
+        payments_collected: 0,
+        grace_period_seconds: 0,
+      })
+    )) as any;
+
+    expect(result.status).toBe('overdue');
+    expect(result.payments_outstanding).toBe(1);
+    expect(result.schedule[0].overdue).toBe(true);
+  });
+
+  it('is active (not overdue) while still within grace window', async () => {
+    const GRACE = 3600; // 1 hour grace
+    // 1 period elapsed but only 30 minutes into grace
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + MONTHLY + 1800, // 30 min after due
+        payments_collected: 0,
+        grace_period_seconds: GRACE,
+      })
+    )) as any;
+
+    // Still within grace — should be active, not overdue
+    expect(result.status).toBe('active');
+    expect(result.schedule[0].overdue).toBe(false);
+  });
+
+  it('is overdue immediately after grace expires', async () => {
+    const GRACE = 3600;
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + MONTHLY + GRACE + 1, // 1 s past grace
+        payments_collected: 0,
+        grace_period_seconds: GRACE,
+      })
+    )) as any;
+
+    expect(result.status).toBe('overdue');
+    expect(result.schedule[0].overdue).toBe(true);
+  });
+
+  it('grace_period_ends is set to the overdue period grace end', async () => {
+    const GRACE = DAILY;
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + MONTHLY + DAILY + 1,
+        payments_collected: 0,
+        grace_period_seconds: GRACE,
+      })
+    )) as any;
+
+    const expected = new Date((BASE_TIME + GRACE) * 1000).toISOString();
+    expect(result.grace_period_ends).toBe(expected);
+  });
+
+  it('grace_period_ends is null when nothing is overdue', async () => {
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + MONTHLY + 1,
+        payments_collected: 1,
+      })
+    )) as any;
+
+    expect(result.grace_period_ends).toBeNull();
+  });
+});
+
+// ── Status: cancelled ────────────────────────────────────────────────────────
+
+describe('status: cancelled', () => {
+  it('is cancelled when cancelled_timestamp is in the past', async () => {
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + 2 * MONTHLY,
+        cancelled_timestamp: BASE_TIME + MONTHLY,
+      })
+    )) as any;
+
+    expect(result.status).toBe('cancelled');
+    expect(result.cancelled_date).toBe(new Date((BASE_TIME + MONTHLY) * 1000).toISOString());
+  });
+
+  it('stops generating schedule entries after cancellation', async () => {
+    // Cancelled after period 1 ends; 3 periods would have elapsed otherwise
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + 3 * MONTHLY + 1,
+        cancelled_timestamp: BASE_TIME + MONTHLY + 1,
+        payments_collected: 0,
+      })
+    )) as any;
+
+    // Only 1 period should appear in schedule (the one covering the cancellation time)
+    expect(result.schedule.length).toBeLessThanOrEqual(2);
+    expect(result.status).toBe('cancelled');
+  });
+
+  it('is not cancelled when cancelled_timestamp is in the future', async () => {
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + MONTHLY,
+        cancelled_timestamp: BASE_TIME + 3 * MONTHLY, // future
+        payments_collected: 1,
+      })
+    )) as any;
+
+    expect(result.status).toBe('active');
+  });
+});
+
+// ── Status: expired ──────────────────────────────────────────────────────────
+
+describe('status: expired', () => {
+  it('is expired when all fixed-term periods have elapsed', async () => {
+    const result = (await manageSubscription(
+      makeInput({
+        total_periods: 3,
+        current_timestamp: BASE_TIME + 3 * MONTHLY + 1,
+        payments_collected: 3,
+      })
+    )) as any;
+
+    expect(result.status).toBe('expired');
+    expect(result.end_date).toBe(new Date((BASE_TIME + 3 * MONTHLY) * 1000).toISOString());
+  });
+
+  it('is active just before a fixed-term subscription expires', async () => {
+    const result = (await manageSubscription(
+      makeInput({
+        total_periods: 3,
+        current_timestamp: BASE_TIME + 3 * MONTHLY - 1,
+        payments_collected: 2,
+      })
+    )) as any;
+
+    expect(result.status).not.toBe('expired');
+  });
+
+  it('schedule does not exceed total_periods', async () => {
+    const result = (await manageSubscription(
+      makeInput({
+        total_periods: 2,
+        current_timestamp: BASE_TIME + 10 * MONTHLY,
+        payments_collected: 2,
+      })
+    )) as any;
+
+    expect(result.schedule).toHaveLength(2);
+  });
+});
+
+// ── Payment totals ───────────────────────────────────────────────────────────
+
+describe('payment totals', () => {
+  it('correctly computes total_collected_amount', async () => {
+    const result = (await manageSubscription(
+      makeInput({
+        amount_per_period: 50,
+        current_timestamp: BASE_TIME + 5 * MONTHLY + 1,
+        payments_collected: 3,
+      })
+    )) as any;
+
+    expect(result.total_collected_amount).toBe('150.0000000');
+    expect(result.payments_collected).toBe(3);
+  });
+
+  it('correctly computes total_outstanding_amount', async () => {
+    const result = (await manageSubscription(
+      makeInput({
+        amount_per_period: 25,
+        current_timestamp: BASE_TIME + 4 * MONTHLY + 1,
+        payments_collected: 1,
+      })
+    )) as any;
+
+    // 4 periods elapsed; 1 collected → 3 outstanding
+    expect(result.payments_outstanding).toBe(3);
+    expect(result.total_outstanding_amount).toBe('75.0000000');
+  });
+
+  it('payments_collected is capped to collectible periods', async () => {
+    // Only 2 periods elapsed but payments_collected says 5
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + 2 * MONTHLY + 1,
+        payments_collected: 5,
+      })
+    )) as any;
+
+    expect(result.payments_collected).toBe(2);
+    expect(result.payments_outstanding).toBe(0);
+  });
+});
+
+// ── Schedule correctness ─────────────────────────────────────────────────────
+
+describe('schedule correctness', () => {
+  it('schedule has correct period count', async () => {
+    const result = (await manageSubscription(
+      makeInput({ current_timestamp: BASE_TIME + 3 * MONTHLY + 1 })
+    )) as any;
+
+    expect(result.schedule).toHaveLength(3);
+  });
+
+  it('schedule periods are 1-indexed', async () => {
+    const result = (await manageSubscription(
+      makeInput({ current_timestamp: BASE_TIME + 2 * MONTHLY + 1 })
+    )) as any;
+
+    expect(result.schedule[0].period).toBe(1);
+    expect(result.schedule[1].period).toBe(2);
+  });
+
+  it('schedule due_date increments correctly', async () => {
+    const result = (await manageSubscription(
+      makeInput({ current_timestamp: BASE_TIME + 3 * MONTHLY + 1 })
+    )) as any;
+
+    expect(result.schedule[0].due_date).toBe(new Date(BASE_TIME * 1000).toISOString());
+    expect(result.schedule[1].due_date).toBe(new Date((BASE_TIME + MONTHLY) * 1000).toISOString());
+    expect(result.schedule[2].due_date).toBe(
+      new Date((BASE_TIME + 2 * MONTHLY) * 1000).toISOString()
+    );
+  });
+
+  it('schedule grace_ends equals due_date + grace_period_seconds', async () => {
+    const GRACE = 7200;
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + MONTHLY + 1,
+        grace_period_seconds: GRACE,
+      })
+    )) as any;
+
+    const period = result.schedule[0];
+    const dueDateTs = new Date(period.due_date).getTime() / 1000;
+    const graceEndsTs = new Date(period.grace_ends).getTime() / 1000;
+    expect(graceEndsTs - dueDateTs).toBe(GRACE);
+  });
+
+  it('collected flag is true only for periods within payments_collected', async () => {
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + 3 * MONTHLY + 1,
+        payments_collected: 2,
+      })
+    )) as any;
+
+    expect(result.schedule[0].collected).toBe(true);
+    expect(result.schedule[1].collected).toBe(true);
+    expect(result.schedule[2].collected).toBe(false);
+  });
+});
+
+// ── Asset label ──────────────────────────────────────────────────────────────
+
+describe('asset label', () => {
+  it('formats issued asset as CODE:ISSUER', async () => {
+    const result = (await manageSubscription(
+      makeInput({ asset_code: 'USDC', asset_issuer: ISSUER, current_timestamp: BASE_TIME })
+    )) as any;
+
+    expect(result.asset).toBe(`USDC:${ISSUER}`);
+  });
+
+  it('formats native asset as just the code when no issuer', async () => {
+    const input = makeInput({ current_timestamp: BASE_TIME });
+    delete (input as any).asset_issuer;
+    const result = (await manageSubscription({ ...input, asset_code: 'XLM' })) as any;
+
+    expect(result.asset).toBe('XLM');
+  });
+});
+
+// ── Validation errors ────────────────────────────────────────────────────────
+
+describe('validation errors', () => {
+  it('throws when subscriber and merchant are identical', async () => {
+    await expect(manageSubscription(makeInput({ merchant: SUBSCRIBER }))).rejects.toThrow(
+      'subscriber and merchant must be different'
+    );
+  });
+
+  it('throws when cancelled_timestamp is before start_timestamp', async () => {
+    await expect(
+      manageSubscription(makeInput({ cancelled_timestamp: BASE_TIME - 1 }))
+    ).rejects.toThrow('cancelled_timestamp must be after start_timestamp');
+  });
+
+  it('throws on invalid subscriber key format', async () => {
+    await expect(manageSubscription(makeInput({ subscriber: 'INVALID_KEY' }))).rejects.toThrow();
+  });
+
+  it('throws on negative amount_per_period', async () => {
+    await expect(manageSubscription(makeInput({ amount_per_period: -1 }))).rejects.toThrow();
+  });
+
+  it('throws on zero period_seconds', async () => {
+    await expect(manageSubscription(makeInput({ period_seconds: 0 }))).rejects.toThrow();
+  });
+
+  it('throws on empty asset_code', async () => {
+    await expect(manageSubscription(makeInput({ asset_code: '' }))).rejects.toThrow();
+  });
+
+  it('throws on asset_code longer than 12 characters', async () => {
+    await expect(
+      manageSubscription(makeInput({ asset_code: 'TOOLONGASSETCODE' }))
+    ).rejects.toThrow();
+  });
+
+  it('throws on negative payments_collected', async () => {
+    await expect(manageSubscription(makeInput({ payments_collected: -1 }))).rejects.toThrow();
+  });
+});
+
+// ── Indefinite subscription ──────────────────────────────────────────────────
+
+describe('indefinite subscription', () => {
+  it('end_date is null for indefinite subscriptions', async () => {
+    const result = (await manageSubscription(
+      makeInput({ current_timestamp: BASE_TIME + MONTHLY + 1 })
+    )) as any;
+
+    expect(result.end_date).toBeNull();
+  });
+
+  it('schedule keeps growing beyond any total_periods', async () => {
+    const result = (await manageSubscription(
+      makeInput({ current_timestamp: BASE_TIME + 12 * MONTHLY + 1, payments_collected: 12 })
+    )) as any;
+
+    expect(result.schedule.length).toBeGreaterThanOrEqual(12);
+  });
+});
+
+// ── Edge cases ───────────────────────────────────────────────────────────────
+
+describe('edge cases', () => {
+  it('handles daily billing correctly', async () => {
+    const result = (await manageSubscription({
+      subscriber: SUBSCRIBER,
+      merchant: MERCHANT,
+      amount_per_period: 10,
+      asset_code: 'XLM',
+      period_seconds: DAILY,
+      start_timestamp: BASE_TIME,
+      payments_collected: 0,
+      grace_period_seconds: 0,
+      current_timestamp: BASE_TIME + 7 * DAILY + 1,
+    })) as any;
+
+    expect(result.schedule).toHaveLength(7);
+    expect(result.payments_outstanding).toBe(7);
+  });
+
+  it('handles exact boundary — one second before period ends', async () => {
+    // Exactly at the start of the second period but not into it
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + MONTHLY - 1,
+        payments_collected: 0,
+      })
+    )) as any;
+
+    // 0 full periods elapsed → empty schedule
+    expect(result.schedule).toHaveLength(0);
+  });
+
+  it('returns correct output types', async () => {
+    const result = (await manageSubscription(
+      makeInput({
+        current_timestamp: BASE_TIME + MONTHLY + 1,
+        payments_collected: 1,
+      })
+    )) as any;
+
+    expect(typeof result.status).toBe('string');
+    expect(typeof result.amount_per_period).toBe('string');
+    expect(typeof result.period_seconds).toBe('number');
+    expect(Array.isArray(result.schedule)).toBe(true);
+    expect(typeof result.payments_collected).toBe('number');
+    expect(typeof result.payments_outstanding).toBe('number');
+  });
+});


### PR DESCRIPTION
## Summary

Implements issue #175 — Subscription/Recurring Payment Contract for the Pulsar MCP server.

Adds a new `manage_subscription` tool that models a **pull-payment recurring billing contract** on the Stellar/Soroban network. The tool is pure computation (no network calls), following the same architecture pattern as `compute_vesting_schedule`.

---

## What's Changed

### `src/schemas/tools.ts`
- Added `ManageSubscriptionInputSchema` and `ManageSubscriptionInput` type
- Covers: `subscriber`, `merchant`, `amount_per_period`, `asset_code`, `asset_issuer` (optional for XLM), `period_seconds`, `start_timestamp`, `total_periods` (optional, fixed-term), `cancelled_timestamp` (optional), `payments_collected`, `grace_period_seconds`, `current_timestamp` (optional override)

### `src/tools/manage_subscription.ts`
- New tool implementing pull-payment state derivation
- Computes subscription **status**: `pending` | `active` | `overdue` | `cancelled` | `expired`
- Returns full **billing schedule** with per-period due dates, grace windows, collected/overdue flags
- Outputs: `payments_collected`, `payments_outstanding`, `total_collected_amount`, `total_outstanding_amount`, `next_payment_due`, `last_payment_date`, `grace_period_ends`
- Cross-field validation: `subscriber !== merchant`, `cancelled_timestamp >= start_timestamp`
- Handles: grace windows, mid-term cancellation, fixed-term expiry, indefinite subscriptions, capped collection counts

### `src/index.ts`
- Registered `manage_subscription` in `ListTools` with full JSON Schema descriptor
- Added `case 'manage_subscription'` handler in `CallTool` switch

### `tests/unit/manage_subscription.test.ts`
- 30+ deterministic unit tests (fixed epoch) covering every status path, schedule invariants, boundary conditions, asset label formatting, and all validation error cases

### `tests/integration/manage_subscription.test.ts`
- 7 wall-clock integration scenarios: active monthly SaaS, overdue with zero grace, cancelled mid-term, expired 12-month fixed-term, pending future start, weekly billing with partial collection, output shape invariants

---

## Acceptance Criteria

- [x] Pull-payment model implemented using existing Pulsar tool architecture
- [x] Strict Zod input validation with detailed error messages
- [x] DRY — reuses `StellarPublicKeySchema`, `McpToolHandler`, `PulsarValidationError` from existing modules
- [x] Unit tests with deterministic fixtures
- [x] Integration tests with real wall-clock timestamps
- [x] Tool registered and documented in the MCP server's `ListTools` response
- [x] AI-ready tool schema available via `manage_subscription` in the MCP tool listing

---

## Testing

```bash
npm test
```

Closes #175 