### PR TITLE
feat: implement account merge tool with validation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,35 @@ Builds a Stellar transaction for deploying a Soroban smart contract. Supports tw
 
 ---
 
+### `account_merge`
+
+Builds an unsigned account merge transaction that closes a source Stellar account and transfers its remaining XLM to a destination account. Validates both accounts exist before constructing the transaction.
+
+**Input:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `source_account` | `string` | Yes | Stellar public key (`G...`) of the account being merged |
+| `destination_account` | `string` | Yes | Stellar public key (`G...`) of the destination account that receives the merged XLM |
+| `network` | `string` | No | Override network: `mainnet`, `testnet`, `futurenet`, `custom` |
+
+**Output:**
+
+```jsonc
+{
+  "source_account": "GBBD...",
+  "destination_account": "GBBD...",
+  "network": "testnet",
+  "transaction_xdr": "AAAAAgAAAAE..."
+}
+```
+
+**Example prompt:**
+
+> _"Build an account merge transaction from GBBD... into GBDF... on testnet."_
+
+---
+
 ## Example Prompts & Workflows
 
 These are real-world workflows that become possible once pulsar is connected to your AI assistant.

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,16 +1,16 @@
-import dotenv from "dotenv";
-import { z } from "zod";
+import dotenv from 'dotenv';
+import { z } from 'zod';
 
 // Load .env if present
 dotenv.config();
 
 const configSchema = z.object({
-  stellarNetwork: z.enum(["mainnet", "testnet", "futurenet", "custom"]).default("testnet"),
+  stellarNetwork: z.enum(['mainnet', 'testnet', 'futurenet', 'custom']).default('testnet'),
   horizonUrl: z.string().url().optional(),
   sorobanRpcUrl: z.string().url().optional(),
-  stellarSecretKey: z.string().startsWith("S").length(56).optional(),
-  stellarCliPath: z.string().default("stellar"),
-  logLevel: z.enum(["error", "warn", "info", "debug"]).default("info"),
+  stellarSecretKey: z.string().startsWith('S').length(56).optional(),
+  stellarCliPath: z.string().default('stellar'),
+  logLevel: z.enum(['error', 'warn', 'info', 'debug']).default('info'),
 });
 
 const rawConfig = {
@@ -18,15 +18,18 @@ const rawConfig = {
   horizonUrl: process.env.HORIZON_URL || undefined,
   sorobanRpcUrl: process.env.SOROBAN_RPC_URL || undefined,
   stellarSecretKey: process.env.STELLAR_SECRET_KEY || undefined,
-  stellarCliPath: process.env.STELLAR_CLI_PATH || "stellar",
-  logLevel: process.env.LOG_LEVEL || "info",
+  stellarCliPath: process.env.STELLAR_CLI_PATH || 'stellar',
+  logLevel: process.env.LOG_LEVEL || 'info',
 };
 
 // Validate environment variables
 const parsed = configSchema.safeParse(rawConfig);
 
 if (!parsed.success) {
-  console.error("❌ Invalid environment variables:", JSON.stringify(parsed.error.format(), null, 2));
+  console.error(
+    '❌ Invalid environment variables:',
+    JSON.stringify(parsed.error.format(), null, 2)
+  );
   process.exit(1);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,28 @@
 #!/usr/bin/env node
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema, ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ErrorCode,
+  McpError,
+} from '@modelcontextprotocol/sdk/types.js';
 
-import { config } from "./config.js";
-import { fetchContractSpec, fetchContractSpecSchema } from "./tools/fetch_contract_spec.js";
+import { config } from './config.js';
+import { fetchContractSpec, fetchContractSpecSchema } from './tools/fetch_contract_spec.js';
 import { submitTransaction } from './tools/submit_transaction.js';
 import { simulateTransaction } from './tools/simulate_transaction.js';
 import { getAccountBalance } from './tools/get_account_balance.js';
 import { computeVestingSchedule } from './tools/compute_vesting_schedule.js';
 import { deployContract } from './tools/deploy_contract.js';
+import { accountMerge } from './tools/account_merge.js';
 import {
   GetAccountBalanceInputSchema,
   SubmitTransactionInputSchema,
   SimulateTransactionInputSchema,
   ComputeVestingScheduleInputSchema,
   DeployContractInputSchema,
+  AccountMergeInputSchema,
 } from './schemas/tools.js';
 import logger from './logger.js';
 import { PulsarError, PulsarNetworkError, PulsarValidationError } from './errors.js';
@@ -38,7 +45,7 @@ class PulsarServer {
         capabilities: {
           tools: {},
         },
-      },
+      }
     );
 
     this.setupHandlers();
@@ -50,7 +57,8 @@ class PulsarServer {
       tools: [
         {
           name: 'get_account_balance',
-          description: 'Get the current XLM and issued asset balances for a Stellar account. Optionally filter by asset code and/or issuer.',
+          description:
+            'Get the current XLM and issued asset balances for a Stellar account. Optionally filter by asset code and/or issuer.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -116,28 +124,29 @@ class PulsarServer {
           },
         },
         {
-          name: "fetch_contract_spec",
+          name: 'fetch_contract_spec',
           description:
-            "Fetch the ABI/interface spec of a deployed Soroban contract. Returns decoded function signatures, parameter types, and emitted event schemas.",
+            'Fetch the ABI/interface spec of a deployed Soroban contract. Returns decoded function signatures, parameter types, and emitted event schemas.',
           inputSchema: {
-            type: "object",
+            type: 'object',
             properties: {
               contract_id: {
-                type: "string",
-                description: "The Soroban contract address (C...)",
+                type: 'string',
+                description: 'The Soroban contract address (C...)',
               },
               network: {
-                type: "string",
-                enum: ["mainnet", "testnet", "futurenet", "custom"],
-                description: "Override the active network for this call.",
+                type: 'string',
+                enum: ['mainnet', 'testnet', 'futurenet', 'custom'],
+                description: 'Override the active network for this call.',
               },
             },
-            required: ["contract_id"],
+            required: ['contract_id'],
           },
         },
         {
           name: 'simulate_transaction',
-          description: 'Simulates a transaction on the Soroban RPC and returns results, footprint, fees, and events.',
+          description:
+            'Simulates a transaction on the Soroban RPC and returns results, footprint, fees, and events.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -156,7 +165,8 @@ class PulsarServer {
         },
         {
           name: 'compute_vesting_schedule',
-          description: 'Calculate a token vesting / timelock release schedule for team, investors, or advisors. Returns released and unreleased amounts plus a period-by-period breakdown.',
+          description:
+            'Calculate a token vesting / timelock release schedule for team, investors, or advisors. Returns released and unreleased amounts plus a period-by-period breakdown.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -210,23 +220,28 @@ class PulsarServer {
               mode: {
                 type: 'string',
                 enum: ['direct', 'factory'],
-                description: "Deployment mode: 'direct' (built-in deployer) or 'factory' (via factory contract)",
+                description:
+                  "Deployment mode: 'direct' (built-in deployer) or 'factory' (via factory contract)",
               },
               source_account: {
                 type: 'string',
-                description: 'Stellar public key (G...) that will deploy the contract and pay fees.',
+                description:
+                  'Stellar public key (G...) that will deploy the contract and pay fees.',
               },
               wasm_hash: {
                 type: 'string',
-                description: 'SHA-256 hash of the uploaded WASM as 64 hex characters. Required for direct mode.',
+                description:
+                  'SHA-256 hash of the uploaded WASM as 64 hex characters. Required for direct mode.',
               },
               salt: {
                 type: 'string',
-                description: 'Optional 32-byte salt as 64 hex characters for deterministic address. Random if omitted.',
+                description:
+                  'Optional 32-byte salt as 64 hex characters for deterministic address. Random if omitted.',
               },
               factory_contract_id: {
                 type: 'string',
-                description: 'Soroban contract ID (C...) of the factory contract. Required for factory mode.',
+                description:
+                  'Soroban contract ID (C...) of the factory contract. Required for factory mode.',
               },
               deploy_function: {
                 type: 'string',
@@ -234,7 +249,8 @@ class PulsarServer {
               },
               deploy_args: {
                 type: 'array',
-                description: "Arguments for factory deploy function as typed SCVal objects. Each item: { type?: 'symbol'|'string'|'u32'|'i32'|'u64'|'i64'|'u128'|'i128'|'bool'|'address'|'bytes'|'void', value: any }",
+                description:
+                  "Arguments for factory deploy function as typed SCVal objects. Each item: { type?: 'symbol'|'string'|'u32'|'i32'|'u64'|'i64'|'u128'|'i128'|'bool'|'address'|'bytes'|'void', value: any }",
               },
               network: {
                 type: 'string',
@@ -243,6 +259,31 @@ class PulsarServer {
               },
             },
             required: ['mode', 'source_account'],
+          },
+        },
+        {
+          name: 'account_merge',
+          description:
+            'Builds an unsigned Stellar account merge transaction that closes a source account and transfers its remaining XLM to the destination account. Validates that both accounts exist before constructing the transaction.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              source_account: {
+                type: 'string',
+                description: 'Stellar public key (G...) of the account being merged.',
+              },
+              destination_account: {
+                type: 'string',
+                description:
+                  'Stellar public key (G...) of the destination account that receives the merged XLM.',
+              },
+              network: {
+                type: 'string',
+                enum: ['mainnet', 'testnet', 'futurenet', 'custom'],
+                description: 'Override the configured network for this call.',
+              },
+            },
+            required: ['source_account', 'destination_account'],
           },
         },
       ],
@@ -258,7 +299,10 @@ class PulsarServer {
           case 'get_account_balance': {
             const parsed = GetAccountBalanceInputSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for get_account_balance`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for get_account_balance`,
+                parsed.error.format()
+              );
             }
             const result = await getAccountBalance(parsed.data);
             return {
@@ -274,16 +318,22 @@ class PulsarServer {
           case 'fetch_contract_spec': {
             const parsed = fetchContractSpecSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for fetch_contract_spec`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for fetch_contract_spec`,
+                parsed.error.format()
+              );
             }
             const result = await fetchContractSpec(parsed.data);
-            return { content: [{ type: "text", text: JSON.stringify(result) }] };
+            return { content: [{ type: 'text', text: JSON.stringify(result) }] };
           }
 
           case 'submit_transaction': {
             const parsed = SubmitTransactionInputSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for submit_transaction`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for submit_transaction`,
+                parsed.error.format()
+              );
             }
             const result = await submitTransaction(parsed.data);
             return {
@@ -294,7 +344,10 @@ class PulsarServer {
           case 'simulate_transaction': {
             const parsed = SimulateTransactionInputSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for simulate_transaction`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for simulate_transaction`,
+                parsed.error.format()
+              );
             }
             const result = await simulateTransaction(parsed.data);
             return {
@@ -305,7 +358,10 @@ class PulsarServer {
           case 'compute_vesting_schedule': {
             const parsed = ComputeVestingScheduleInputSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for compute_vesting_schedule`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for compute_vesting_schedule`,
+                parsed.error.format()
+              );
             }
             const result = await computeVestingSchedule(parsed.data);
             return {
@@ -316,9 +372,26 @@ class PulsarServer {
           case 'deploy_contract': {
             const parsed = DeployContractInputSchema.safeParse(args);
             if (!parsed.success) {
-              throw new PulsarValidationError(`Invalid input for deploy_contract`, parsed.error.format());
+              throw new PulsarValidationError(
+                `Invalid input for deploy_contract`,
+                parsed.error.format()
+              );
             }
             const result = await deployContract(parsed.data);
+            return {
+              content: [{ type: 'text', text: JSON.stringify(result) }],
+            };
+          }
+
+          case 'account_merge': {
+            const parsed = AccountMergeInputSchema.safeParse(args);
+            if (!parsed.success) {
+              throw new PulsarValidationError(
+                `Invalid input for account_merge`,
+                parsed.error.format()
+              );
+            }
+            const result = await accountMerge(parsed.data);
             return {
               content: [{ type: 'text', text: JSON.stringify(result) }],
             };
@@ -343,10 +416,9 @@ class PulsarServer {
       throw error;
     } else {
       // Convert unknown errors to PulsarNetworkError as per requirements
-      pulsarError = new PulsarNetworkError(
-        error instanceof Error ? error.message : String(error),
-        { originalError: error }
-      );
+      pulsarError = new PulsarNetworkError(error instanceof Error ? error.message : String(error), {
+        originalError: error,
+      });
     }
 
     logger.error(
@@ -384,9 +456,7 @@ class PulsarServer {
   async run() {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    logger.info(
-      `pulsar MCP server v1.0.0 is running on ${config.stellarNetwork}...`,
-    );
+    logger.info(`pulsar MCP server v1.0.0 is running on ${config.stellarNetwork}...`);
   }
 }
 
@@ -395,4 +465,3 @@ pulsar.run().catch((error) => {
   logger.fatal({ error }, '❌ Fatal error in pulsar server');
   process.exit(1);
 });
-

--- a/src/schemas/tools.test.ts
+++ b/src/schemas/tools.test.ts
@@ -3,44 +3,45 @@
  * 100% coverage of all tool-specific validators.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect } from 'vitest';
 
 import {
   GetAccountBalanceInputSchema,
   SubmitTransactionInputSchema,
   ContractReadInputSchema,
-} from "./tools.js";
+  AccountMergeInputSchema,
+} from './tools.js';
 
 // ============================================================================
 // GetAccountBalanceInputSchema
 // ============================================================================
 
-describe("GetAccountBalanceInputSchema", () => {
-  it("accepts valid account_id alone", () => {
+describe('GetAccountBalanceInputSchema', () => {
+  it('accepts valid account_id alone', () => {
     const input = {
-      account_id: "GABCDEFGHJKMNPQRSTUVWXYZ234567ABCDEFGHJKMNPQRSTUVWXYZ234",
+      account_id: 'GABCDEFGHJKMNPQRSTUVWXYZ234567ABCDEFGHJKMNPQRSTUVWXYZ234',
     };
     const result = GetAccountBalanceInputSchema.safeParse(input);
     expect(result.success).toBe(true);
   });
 
-  it("accepts valid account_id with network override", () => {
+  it('accepts valid account_id with network override', () => {
     const input = {
-      account_id: "GBTZKYQRSVWXYZABTZKYQRSVWXYZABTZKYQRSVWXYZABTZKYQRSVWXYZ",
-      network: "testnet",
+      account_id: 'GBTZKYQRSVWXYZABTZKYQRSVWXYZABTZKYQRSVWXYZABTZKYQRSVWXYZ',
+      network: 'testnet',
     };
     const result = GetAccountBalanceInputSchema.safeParse(input);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.network).toBe("testnet");
+      expect(result.data.network).toBe('testnet');
     }
   });
 
-  it("accepts all valid networks", () => {
-    const networks = ["mainnet", "testnet", "futurenet", "custom"];
+  it('accepts all valid networks', () => {
+    const networks = ['mainnet', 'testnet', 'futurenet', 'custom'];
     networks.forEach((network) => {
       const input = {
-        account_id: "GABCDEFGHJKMNPQRSTUVWXYZ234567ABCDEFGHJKMNPQRSTUVWXYZ234",
+        account_id: 'GABCDEFGHJKMNPQRSTUVWXYZ234567ABCDEFGHJKMNPQRSTUVWXYZ234',
         network,
       };
       const result = GetAccountBalanceInputSchema.safeParse(input);
@@ -48,32 +49,32 @@ describe("GetAccountBalanceInputSchema", () => {
     });
   });
 
-  it("rejects missing account_id", () => {
-    const input = { network: "testnet" };
+  it('rejects missing account_id', () => {
+    const input = { network: 'testnet' };
     const result = GetAccountBalanceInputSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
 
-  it("rejects invalid account_id", () => {
+  it('rejects invalid account_id', () => {
     const input = {
-      account_id: "INVALID_KEY",
+      account_id: 'INVALID_KEY',
     };
     const result = GetAccountBalanceInputSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
 
-  it("rejects invalid network", () => {
+  it('rejects invalid network', () => {
     const input = {
-      account_id: "GDZSTFXVCDTUJ76ZAV2HA72KYQMQPQH3S7WVMSZOHMQG4G4MWCZJ6FG7",
-      network: "unknown",
+      account_id: 'GDZSTFXVCDTUJ76ZAV2HA72KYQMQPQH3S7WVMSZOHMQG4G4MWCZJ6FG7',
+      network: 'unknown',
     };
     const result = GetAccountBalanceInputSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
 
-  it("makes network optional", () => {
+  it('makes network optional', () => {
     const input = {
-      account_id: "GDZSTFXVCDTUJ76ZAV2HA72KYQMQPQH3S7WVMSZOHMQG4G4MWCZJ6FG7",
+      account_id: 'GDZSTFXVCDTUJ76ZAV2HA72KYQMQPQH3S7WVMSZOHMQG4G4MWCZJ6FG7',
     };
     const result = GetAccountBalanceInputSchema.safeParse(input);
     expect(result.success).toBe(true);
@@ -84,13 +85,62 @@ describe("GetAccountBalanceInputSchema", () => {
 });
 
 // ============================================================================
+// AccountMergeInputSchema
+// ============================================================================
+
+describe('AccountMergeInputSchema', () => {
+  const input = {
+    source_account: 'GABCDEFGHJKMNPQRSTUVWXYZ234567ABCDEFGHJKMNPQRSTUVWXYZ234',
+    destination_account: 'GBABCDEFGHJKMNPQRSTUVWXYZ234567ABCDEFGHJKMNPQRSTUVWXYZ235',
+  };
+
+  it('accepts valid source and destination', () => {
+    const result = AccountMergeInputSchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing source_account', () => {
+    const result = AccountMergeInputSchema.safeParse({
+      destination_account: input.destination_account,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing destination_account', () => {
+    const result = AccountMergeInputSchema.safeParse({
+      source_account: input.source_account,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid destination_account', () => {
+    const result = AccountMergeInputSchema.safeParse({
+      source_account: input.source_account,
+      destination_account: 'INVALID',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a network override', () => {
+    const result = AccountMergeInputSchema.safeParse({
+      ...input,
+      network: 'testnet',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.network).toBe('testnet');
+    }
+  });
+});
+
+// ============================================================================
 // SubmitTransactionInputSchema
 // ============================================================================
 
-describe("SubmitTransactionInputSchema", () => {
-  const validXdr = "AAAAAgAAAABvalidXDRbase64==";
+describe('SubmitTransactionInputSchema', () => {
+  const validXdr = 'AAAAAgAAAABvalidXDRbase64==';
 
-  it("accepts minimal input with just XDR", () => {
+  it('accepts minimal input with just XDR', () => {
     const input = { xdr: validXdr };
     const result = SubmitTransactionInputSchema.safeParse(input);
     expect(result.success).toBe(true);
@@ -102,10 +152,10 @@ describe("SubmitTransactionInputSchema", () => {
     }
   });
 
-  it("accepts valid XDR with all optional fields", () => {
+  it('accepts valid XDR with all optional fields', () => {
     const input = {
       xdr: validXdr,
-      network: "testnet",
+      network: 'testnet',
       sign: true,
       wait_for_result: true,
       wait_timeout_ms: 60_000,
@@ -113,32 +163,32 @@ describe("SubmitTransactionInputSchema", () => {
     const result = SubmitTransactionInputSchema.safeParse(input);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.network).toBe("testnet");
+      expect(result.data.network).toBe('testnet');
       expect(result.data.sign).toBe(true);
       expect(result.data.wait_for_result).toBe(true);
       expect(result.data.wait_timeout_ms).toBe(60_000);
     }
   });
 
-  it("rejects missing XDR", () => {
-    const input = { network: "testnet" };
+  it('rejects missing XDR', () => {
+    const input = { network: 'testnet' };
     const result = SubmitTransactionInputSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
 
-  it("rejects invalid XDR", () => {
-    const input = { xdr: "!!!invalid base64!!!" };
+  it('rejects invalid XDR', () => {
+    const input = { xdr: '!!!invalid base64!!!' };
     const result = SubmitTransactionInputSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
 
-  it("rejects empty XDR", () => {
-    const input = { xdr: "" };
+  it('rejects empty XDR', () => {
+    const input = { xdr: '' };
     const result = SubmitTransactionInputSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
 
-  it("rejects wait_timeout_ms less than 1000 ms", () => {
+  it('rejects wait_timeout_ms less than 1000 ms', () => {
     const input = {
       xdr: validXdr,
       wait_timeout_ms: 999,
@@ -146,11 +196,11 @@ describe("SubmitTransactionInputSchema", () => {
     const result = SubmitTransactionInputSchema.safeParse(input);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0].message).toContain("1000");
+      expect(result.error.issues[0].message).toContain('1000');
     }
   });
 
-  it("rejects wait_timeout_ms greater than 120000 ms", () => {
+  it('rejects wait_timeout_ms greater than 120000 ms', () => {
     const input = {
       xdr: validXdr,
       wait_timeout_ms: 120_001,
@@ -158,11 +208,11 @@ describe("SubmitTransactionInputSchema", () => {
     const result = SubmitTransactionInputSchema.safeParse(input);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0].message).toContain("120000");
+      expect(result.error.issues[0].message).toContain('120000');
     }
   });
 
-  it("accepts wait_timeout_ms at lower bound (1000)", () => {
+  it('accepts wait_timeout_ms at lower bound (1000)', () => {
     const input = {
       xdr: validXdr,
       wait_timeout_ms: 1000,
@@ -174,7 +224,7 @@ describe("SubmitTransactionInputSchema", () => {
     }
   });
 
-  it("accepts wait_timeout_ms at upper bound (120000)", () => {
+  it('accepts wait_timeout_ms at upper bound (120000)', () => {
     const input = {
       xdr: validXdr,
       wait_timeout_ms: 120_000,
@@ -186,7 +236,7 @@ describe("SubmitTransactionInputSchema", () => {
     }
   });
 
-  it("rejects non-integer wait_timeout_ms", () => {
+  it('rejects non-integer wait_timeout_ms', () => {
     const input = {
       xdr: validXdr,
       wait_timeout_ms: 30.5,
@@ -195,16 +245,16 @@ describe("SubmitTransactionInputSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects invalid network", () => {
+  it('rejects invalid network', () => {
     const input = {
       xdr: validXdr,
-      network: "unknown",
+      network: 'unknown',
     };
     const result = SubmitTransactionInputSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
 
-  it("handles sign as boolean", () => {
+  it('handles sign as boolean', () => {
     const input = { xdr: validXdr, sign: false };
     const result = SubmitTransactionInputSchema.safeParse(input);
     expect(result.success).toBe(true);
@@ -213,13 +263,13 @@ describe("SubmitTransactionInputSchema", () => {
     }
   });
 
-  it("rejects sign as non-boolean", () => {
-    const input = { xdr: validXdr, sign: "yes" };
+  it('rejects sign as non-boolean', () => {
+    const input = { xdr: validXdr, sign: 'yes' };
     const result = SubmitTransactionInputSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
 
-  it("handles wait_for_result as boolean", () => {
+  it('handles wait_for_result as boolean', () => {
     const input = { xdr: validXdr, wait_for_result: true };
     const result = SubmitTransactionInputSchema.safeParse(input);
     expect(result.success).toBe(true);
@@ -228,8 +278,8 @@ describe("SubmitTransactionInputSchema", () => {
     }
   });
 
-  it("rejects wait_for_result as non-boolean", () => {
-    const input = { xdr: validXdr, wait_for_result: "definitely" };
+  it('rejects wait_for_result as non-boolean', () => {
+    const input = { xdr: validXdr, wait_for_result: 'definitely' };
     const result = SubmitTransactionInputSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
@@ -239,26 +289,25 @@ describe("SubmitTransactionInputSchema", () => {
 // ContractReadInputSchema
 // ============================================================================
 
-describe("ContractReadInputSchema", () => {
-  const validContractId =
-    "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+describe('ContractReadInputSchema', () => {
+  const validContractId = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
 
-  it("accepts valid contract_id and method", () => {
+  it('accepts valid contract_id and method', () => {
     const input = {
       contract_id: validContractId,
-      method: "get_value",
+      method: 'get_value',
     };
     const result = ContractReadInputSchema.safeParse(input);
     expect(result.success).toBe(true);
   });
 
-  it("accepts valid contract_id, method, and args", () => {
+  it('accepts valid contract_id, method, and args', () => {
     const input = {
       contract_id: validContractId,
-      method: "transfer",
+      method: 'transfer',
       args: {
-        to: "GABCDEFGHJKMNPQRSTUVWXYZ234567ABCDEFGHJKMNPQRSTUVWXYZ234",
-        amount: "1000",
+        to: 'GABCDEFGHJKMNPQRSTUVWXYZ234567ABCDEFGHJKMNPQRSTUVWXYZ234',
+        amount: '1000',
       },
     };
     const result = ContractReadInputSchema.safeParse(input);
@@ -266,87 +315,87 @@ describe("ContractReadInputSchema", () => {
     if (result.success) {
       expect(result.data.args).toEqual({
         to: expect.any(String),
-        amount: "1000",
+        amount: '1000',
       });
     }
   });
 
-  it("rejects missing contract_id", () => {
-    const input = { method: "get_value" };
+  it('rejects missing contract_id', () => {
+    const input = { method: 'get_value' };
     const result = ContractReadInputSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
 
-  it("rejects invalid contract_id", () => {
+  it('rejects invalid contract_id', () => {
     const input = {
-      contract_id: "INVALID_CONTRACT",
-      method: "get_value",
+      contract_id: 'INVALID_CONTRACT',
+      method: 'get_value',
     };
     const result = ContractReadInputSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
 
-  it("rejects missing method", () => {
+  it('rejects missing method', () => {
     const input = { contract_id: validContractId };
     const result = ContractReadInputSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
 
-  it("rejects empty method", () => {
+  it('rejects empty method', () => {
     const input = {
       contract_id: validContractId,
-      method: "",
+      method: '',
     };
     const result = ContractReadInputSchema.safeParse(input);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0].message).toContain("empty");
+      expect(result.error.issues[0].message).toContain('empty');
     }
   });
 
-  it("rejects method with invalid characters (hyphens)", () => {
+  it('rejects method with invalid characters (hyphens)', () => {
     const input = {
       contract_id: validContractId,
-      method: "get-value",
+      method: 'get-value',
     };
     const result = ContractReadInputSchema.safeParse(input);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0].message).toContain("identifier");
+      expect(result.error.issues[0].message).toContain('identifier');
     }
   });
 
-  it("rejects method starting with number", () => {
+  it('rejects method starting with number', () => {
     const input = {
       contract_id: validContractId,
-      method: "123method",
+      method: '123method',
     };
     const result = ContractReadInputSchema.safeParse(input);
     expect(result.success).toBe(false);
   });
 
-  it("accepts valid method names with underscores", () => {
+  it('accepts valid method names with underscores', () => {
     const input = {
       contract_id: validContractId,
-      method: "get_current_value",
+      method: 'get_current_value',
     };
     const result = ContractReadInputSchema.safeParse(input);
     expect(result.success).toBe(true);
   });
 
-  it("accepts valid method names starting with underscore", () => {
+  it('accepts valid method names starting with underscore', () => {
     const input = {
       contract_id: validContractId,
-      method: "_internal_method",
+      method: '_internal_method',
     };
     const result = ContractReadInputSchema.safeParse(input);
     expect(result.success).toBe(true);
   });
 
-  it("makes args optional", () => {
+  it('makes args optional', () => {
     const input = {
       contract_id: validContractId,
-      method: "get_value",
+      method: 'get_value',
     };
     const result = ContractReadInputSchema.safeParse(input);
     expect(result.success).toBe(true);
@@ -355,27 +404,27 @@ describe("ContractReadInputSchema", () => {
     }
   });
 
-  it("accepts empty args object", () => {
+  it('accepts empty args object', () => {
     const input = {
       contract_id: validContractId,
-      method: "get_value",
+      method: 'get_value',
       args: {},
     };
     const result = ContractReadInputSchema.safeParse(input);
     expect(result.success).toBe(true);
   });
 
-  it("accepts args with various value types", () => {
+  it('accepts args with various value types', () => {
     const input = {
       contract_id: validContractId,
-      method: "complex_method",
+      method: 'complex_method',
       args: {
-        string_arg: "value",
+        string_arg: 'value',
         number_arg: 42,
         boolean_arg: true,
         null_arg: null,
         array_arg: [1, 2, 3],
-        object_arg: { nested: "value" },
+        object_arg: { nested: 'value' },
       },
     };
     const result = ContractReadInputSchema.safeParse(input);

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -6,21 +6,21 @@
  * before any RPC calls are made.
  */
 
-import { z } from "zod";
+import { z } from 'zod';
 
 import {
   StellarPublicKeySchema,
   ContractIdSchema,
   XdrBase64Schema,
   NetworkSchema,
-} from "./index.js";
+} from './index.js';
 
 const Hex32Schema = z
   .string()
   .regex(/^[a-fA-F0-9]{64}$/, {
-    message: "Must be a 64-character hex string (32 bytes)",
+    message: 'Must be a 64-character hex string (32 bytes)',
   })
-  .describe("32-byte value encoded as 64 hex characters");
+  .describe('32-byte value encoded as 64 hex characters');
 
 /**
  * Schema for get_account_balance tool
@@ -36,9 +36,7 @@ export const GetAccountBalanceInputSchema = z.object({
   asset_issuer: StellarPublicKeySchema.optional(),
 });
 
-export type GetAccountBalanceInput = z.infer<
-  typeof GetAccountBalanceInputSchema
->;
+export type GetAccountBalanceInput = z.infer<typeof GetAccountBalanceInputSchema>;
 
 /**
  * Schema for submit_transaction tool
@@ -58,14 +56,12 @@ export const SubmitTransactionInputSchema = z.object({
   wait_timeout_ms: z
     .number()
     .int()
-    .min(1000, { message: "wait_timeout_ms must be at least 1000 ms" })
-    .max(120_000, { message: "wait_timeout_ms must not exceed 120000 ms" })
+    .min(1000, { message: 'wait_timeout_ms must be at least 1000 ms' })
+    .max(120_000, { message: 'wait_timeout_ms must not exceed 120000 ms' })
     .default(30_000),
 });
 
-export type SubmitTransactionInput = z.infer<
-  typeof SubmitTransactionInputSchema
->;
+export type SubmitTransactionInput = z.infer<typeof SubmitTransactionInputSchema>;
 
 /**
  * Schema for potential future contract_read tool.
@@ -75,9 +71,9 @@ export const ContractReadInputSchema = z.object({
   contract_id: ContractIdSchema,
   method: z
     .string()
-    .min(1, { message: "Method name cannot be empty" })
+    .min(1, { message: 'Method name cannot be empty' })
     .regex(/^[a-zA-Z_][a-zA-Z0-9_]*$/, {
-      message: "Method name must be a valid identifier",
+      message: 'Method name must be a valid identifier',
     }),
   args: z.record(z.unknown()).optional(),
 });
@@ -96,9 +92,7 @@ export const SimulateTransactionInputSchema = z.object({
   network: NetworkSchema.optional(),
 });
 
-export type SimulateTransactionInput = z.infer<
-  typeof SimulateTransactionInputSchema
->;
+export type SimulateTransactionInput = z.infer<typeof SimulateTransactionInputSchema>;
 
 /**
  * Schema for compute_vesting_schedule tool
@@ -113,39 +107,32 @@ export type SimulateTransactionInput = z.infer<
  * - current_timestamp: Optional override for "now" (defaults to current time)
  */
 export const ComputeVestingScheduleInputSchema = z.object({
-  total_amount: z
-    .number()
-    .positive({ message: "total_amount must be positive" }),
+  total_amount: z.number().positive({ message: 'total_amount must be positive' }),
   start_timestamp: z
     .number()
     .int()
-    .positive({ message: "start_timestamp must be a positive Unix timestamp" }),
-  cliff_seconds: z
-    .number()
-    .int()
-    .nonnegative({ message: "cliff_seconds must be non-negative" }),
+    .positive({ message: 'start_timestamp must be a positive Unix timestamp' }),
+  cliff_seconds: z.number().int().nonnegative({ message: 'cliff_seconds must be non-negative' }),
   vesting_duration_seconds: z
     .number()
     .int()
-    .positive({ message: "vesting_duration_seconds must be positive" }),
+    .positive({ message: 'vesting_duration_seconds must be positive' }),
   release_frequency_seconds: z
     .number()
     .int()
-    .positive({ message: "release_frequency_seconds must be positive" }),
+    .positive({ message: 'release_frequency_seconds must be positive' }),
   beneficiary_type: z
-    .enum(["team", "investor", "advisor", "other"])
-    .describe("Type of beneficiary receiving the vesting tokens"),
+    .enum(['team', 'investor', 'advisor', 'other'])
+    .describe('Type of beneficiary receiving the vesting tokens'),
   current_timestamp: z
     .number()
     .int()
     .positive()
     .optional()
-    .describe("Optional override for current time as Unix timestamp"),
+    .describe('Optional override for current time as Unix timestamp'),
 });
 
-export type ComputeVestingScheduleInput = z.infer<
-  typeof ComputeVestingScheduleInputSchema
->;
+export type ComputeVestingScheduleInput = z.infer<typeof ComputeVestingScheduleInputSchema>;
 
 /**
  * Schema for deploy_contract tool
@@ -164,21 +151,31 @@ export type ComputeVestingScheduleInput = z.infer<
  * - deploy_args: Array of typed SCVal arguments for factory deploy function
  * - network: Optional network override
  */
+export const AccountMergeInputSchema = z.object({
+  source_account: StellarPublicKeySchema.describe(
+    'The Stellar public key of the account being merged.'
+  ),
+  destination_account: StellarPublicKeySchema.describe(
+    'The Stellar public key of the destination account that receives the merged XLM.'
+  ),
+  network: NetworkSchema.optional(),
+});
+
 export const DeployContractInputSchema = z.object({
   mode: z
-    .enum(["direct", "factory"])
-    .describe("Deployment mode: direct (built-in deployer) or factory (via factory contract)"),
+    .enum(['direct', 'factory'])
+    .describe('Deployment mode: direct (built-in deployer) or factory (via a factory contract)'),
   source_account: StellarPublicKeySchema.describe(
-    "The Stellar account that will deploy the contract and pay fees"
+    'The Stellar account that will deploy the contract and pay fees'
   ),
   wasm_hash: Hex32Schema.optional().describe(
-    "SHA-256 hash of the uploaded WASM (64 hex chars). Required for direct mode."
+    'SHA-256 hash of the uploaded WASM (64 hex chars). Required for direct mode.'
   ),
   salt: Hex32Schema.optional().describe(
-    "Optional 32-byte salt for deterministic contract address (64 hex chars). Random if omitted."
+    'Optional 32-byte salt for deterministic contract address (64 hex chars). Random if omitted.'
   ),
   factory_contract_id: ContractIdSchema.optional().describe(
-    "Factory contract ID. Required for factory mode."
+    'Factory contract ID. Required for factory mode.'
   ),
   deploy_function: z
     .string()
@@ -190,28 +187,27 @@ export const DeployContractInputSchema = z.object({
       z.object({
         type: z
           .enum([
-            "symbol",
-            "string",
-            "u32",
-            "i32",
-            "u64",
-            "i64",
-            "u128",
-            "i128",
-            "bool",
-            "address",
-            "bytes",
-            "void",
+            'symbol',
+            'string',
+            'u32',
+            'i32',
+            'u64',
+            'i64',
+            'u128',
+            'i128',
+            'bool',
+            'address',
+            'bytes',
+            'void',
           ])
           .optional()
-          .describe("Soroban SCVal type hint"),
-        value: z.unknown().describe("The value to convert to SCVal"),
+          .describe('Soroban SCVal type hint'),
+        value: z.unknown().describe('The value to convert to SCVal'),
       })
     )
     .optional()
-    .describe("Arguments for factory deploy function as typed SCVal objects"),
+    .describe('Arguments for factory deploy function as typed SCVal objects'),
   network: NetworkSchema.optional(),
 });
 
 export type DeployContractInput = z.infer<typeof DeployContractInputSchema>;
-

--- a/src/services/stellar-cli.ts
+++ b/src/services/stellar-cli.ts
@@ -1,9 +1,9 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 
-import { config } from "../config.js";
-import { PulsarCliError } from "../errors.js";
-import logger from "../logger.js";
+import { config } from '../config.js';
+import { PulsarCliError } from '../errors.js';
+import logger from '../logger.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -13,21 +13,21 @@ const DEFAULT_TIMEOUT_MS = 30_000;
  * Run the Stellar CLI with the given argument array.
  * Args are NEVER joined via string interpolation — execFile handles escaping.
  */
+
 export async function runStellarCli(
   args: string[],
   timeoutMs = DEFAULT_TIMEOUT_MS
 ): Promise<{ stdout: string; stderr: string }> {
   const bin = config.stellarCliPath;
-  logger.debug({ bin, args }, "Executing Stellar CLI command");
+  logger.debug({ bin, args }, 'Executing Stellar CLI command');
   try {
     return await execFileAsync(bin, args, { timeout: timeoutMs });
   } catch (err: unknown) {
     const e = err as { stdout?: string; stderr?: string; message?: string };
     const errorMessage = e.stderr?.trim() || e.message || String(err);
-    throw new PulsarCliError(
-      `Stellar CLI error: ${errorMessage}`,
-      { stdout: e.stdout, stderr: e.stderr }
-    );
+    throw new PulsarCliError(`Stellar CLI error: ${errorMessage}`, {
+      stdout: e.stdout,
+      stderr: e.stderr,
+    });
   }
 }
-

--- a/src/tools/account_merge.ts
+++ b/src/tools/account_merge.ts
@@ -1,0 +1,94 @@
+import { TransactionBuilder, Operation, Networks } from '@stellar/stellar-sdk';
+
+import { config } from '../config.js';
+import { getHorizonServer } from '../services/horizon.js';
+import { AccountMergeInputSchema } from '../schemas/tools.js';
+import type { McpToolHandler } from '../types.js';
+import { PulsarValidationError, PulsarNetworkError } from '../errors.js';
+
+export interface AccountMergeOutput {
+  source_account: string;
+  destination_account: string;
+  network: string;
+  transaction_xdr: string;
+}
+
+function resolveNetworkPassphrase(network: string): string {
+  switch (network) {
+    case 'mainnet':
+      return Networks.PUBLIC;
+    case 'futurenet':
+      return Networks.FUTURENET;
+    case 'testnet':
+    default:
+      return Networks.TESTNET;
+  }
+}
+
+export const accountMerge: McpToolHandler<typeof AccountMergeInputSchema> = async (
+  input: unknown
+) => {
+  const validated = AccountMergeInputSchema.safeParse(input);
+  if (!validated.success) {
+    throw new PulsarValidationError('Invalid input for account_merge', validated.error.format());
+  }
+
+  const { source_account, destination_account, network } = validated.data;
+  const networkName = network ?? config.stellarNetwork;
+
+  if (source_account === destination_account) {
+    throw new PulsarValidationError('source_account and destination_account must differ');
+  }
+
+  const horizonServer = getHorizonServer(networkName);
+  let sourceAccount;
+
+  try {
+    sourceAccount = await horizonServer.loadAccount(source_account);
+  } catch (err: any) {
+    if (err.response?.status === 404) {
+      throw new PulsarNetworkError(
+        `Source account ${source_account} not found. Fund the account before merging.`,
+        { status: 404, account_id: source_account }
+      );
+    }
+    throw new PulsarNetworkError(`Failed to load source account: ${err.message}`, {
+      originalError: err,
+    });
+  }
+
+  try {
+    await horizonServer.loadAccount(destination_account);
+  } catch (err: any) {
+    if (err.response?.status === 404) {
+      throw new PulsarNetworkError(
+        `Destination account ${destination_account} not found. The target account must exist before merging.`,
+        { status: 404, account_id: destination_account }
+      );
+    }
+    throw new PulsarNetworkError(`Failed to load destination account: ${err.message}`, {
+      originalError: err,
+    });
+  }
+
+  const networkPassphrase = resolveNetworkPassphrase(networkName);
+
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: '100',
+    networkPassphrase,
+  })
+    .addOperation(
+      Operation.accountMerge({
+        destination: destination_account,
+      })
+    )
+    .setTimeout(30)
+    .build();
+
+  return {
+    source_account,
+    destination_account,
+    network: networkName,
+    transaction_xdr: tx.toXDR(),
+  };
+};

--- a/tests/integration/decode_ledger_entry.test.ts
+++ b/tests/integration/decode_ledger_entry.test.ts
@@ -34,6 +34,7 @@ describeIfIntegration('decode_ledger_entry (Integration)', () => {
 
     // Test with a sample XDR (this is a minimal valid XDR structure)
     // In practice, you'd fetch real ledger entry XDR from the network
+
     const sampleXdr = 'AAAAAQAAAAA='; // Minimal base64
 
     const result = await decodeLedgerEntry(sampleXdr);

--- a/tests/unit/account_merge.test.ts
+++ b/tests/unit/account_merge.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Account, Keypair, Networks, TransactionBuilder } from '@stellar/stellar-sdk';
+
+import { accountMerge } from '../../src/tools/account_merge.js';
+import { getHorizonServer } from '../../src/services/horizon.js';
+
+vi.mock('../../src/services/horizon.js', () => ({
+  getHorizonServer: vi.fn(),
+}));
+
+describe('accountMerge', () => {
+  const sourceKeypair = Keypair.random();
+  const destinationKeypair = Keypair.random();
+  const SOURCE_ACCOUNT = sourceKeypair.publicKey();
+  const DESTINATION_ACCOUNT = destinationKeypair.publicKey();
+
+  let mockServer: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockServer = {
+      loadAccount: vi.fn(),
+    };
+    vi.mocked(getHorizonServer).mockReturnValue(mockServer);
+  });
+
+  it('builds an unsigned account merge transaction', async () => {
+    mockServer.loadAccount.mockImplementation((accountId: string) => {
+      if (accountId === SOURCE_ACCOUNT) {
+        return Promise.resolve(new Account(SOURCE_ACCOUNT, '1'));
+      }
+      if (accountId === DESTINATION_ACCOUNT) {
+        return Promise.resolve({
+          accountId: () => DESTINATION_ACCOUNT,
+          sequenceNumber: () => '1',
+        });
+      }
+      return Promise.reject(new Error('unexpected account'));
+    });
+
+    const result = (await accountMerge({
+      source_account: SOURCE_ACCOUNT,
+      destination_account: DESTINATION_ACCOUNT,
+    })) as {
+      source_account: string;
+      destination_account: string;
+      network: string;
+      transaction_xdr: string;
+    };
+
+    expect(result.source_account).toBe(SOURCE_ACCOUNT);
+    expect(result.destination_account).toBe(DESTINATION_ACCOUNT);
+    expect(result.network).toBe('testnet');
+    expect(typeof result.transaction_xdr).toBe('string');
+    expect(result.transaction_xdr.length).toBeGreaterThan(0);
+
+    const tx = TransactionBuilder.fromXDR(result.transaction_xdr, Networks.TESTNET);
+    expect(tx.operations).toHaveLength(1);
+    expect((tx.operations[0] as any).destination).toBe(DESTINATION_ACCOUNT);
+  });
+
+  it('rejects when source and destination are the same', async () => {
+    await expect(
+      accountMerge({
+        source_account: SOURCE_ACCOUNT,
+        destination_account: SOURCE_ACCOUNT,
+      })
+    ).rejects.toThrow('source_account and destination_account must differ');
+  });
+
+  it('rejects when source account does not exist', async () => {
+    mockServer.loadAccount.mockRejectedValueOnce({
+      response: { status: 404 },
+      message: 'Not Found',
+    });
+
+    await expect(
+      accountMerge({
+        source_account: SOURCE_ACCOUNT,
+        destination_account: DESTINATION_ACCOUNT,
+      })
+    ).rejects.toThrow('Source account');
+  });
+
+  it('rejects when destination account does not exist', async () => {
+    mockServer.loadAccount.mockImplementation((accountId: string) => {
+      if (accountId === SOURCE_ACCOUNT) {
+        return Promise.resolve(new Account(SOURCE_ACCOUNT, '1'));
+      }
+      return Promise.reject({ response: { status: 404 }, message: 'Not Found' });
+    });
+
+    await expect(
+      accountMerge({
+        source_account: SOURCE_ACCOUNT,
+        destination_account: DESTINATION_ACCOUNT,
+      })
+    ).rejects.toThrow('Destination account');
+  });
+});


### PR DESCRIPTION
close#157

## Summary
Added a new `account_merge` MCP tool that constructs unsigned Stellar account merge transactions. This includes:
- account_merge.ts — implementation for validating accounts and building the merge transaction XDR
- tools.ts — `AccountMergeInputSchema` for input validation
- index.ts — tool registration and MCP handler wiring
- account_merge.test.ts — unit tests covering successful transaction creation and failure cases
- tools.test.ts — schema validation coverage for the new tool
- README.md — documentation for the new `account_merge` tool

## Checklist
- [ ] I have run `npm run lint` and fixed any warnings.
- [ ] I have run `npm run typecheck` and verified no type errors exist.
- [x] I have added/updated tests for my changes.
- [ ] All new and existing tests passed via `npm test`.
- [x] I have updated the README/Documentation if applicable.